### PR TITLE
Improve throughput on Windows

### DIFF
--- a/sw/Makefile
+++ b/sw/Makefile
@@ -39,7 +39,7 @@ endif
 ifneq (,$(filter $(TARGET_OS),Windows_NT Windows win win32 win64))
     CFLAGS := $(filter-out -DALLOW_CREATE_LINK, $(CFLAGS))
     # -static works for Vista+, but doesn't work for XP
-    LDFLAGS += -lws2_32 -static
+    LDFLAGS += -lws2_32 -lwinmm -static
     OBJDIR := objs.win64
     HOSTSMASH_SRCS += mingw-realpath.c
     CC := x86_64-w64-mingw32-gcc


### PR DESCRIPTION
1. Increase timer accuracy for Sleep() and other timer related APIs, by using timeGetDevCaps() and timeBeginPeriod()
2. Ensure that ReadFile to the COM port of 128-bytes doesn't block for up to 128ms.  This can be controlled by SetCommTimeouts() with appropriate values.  Because the program is not using Overlapped-I/O, the ReadFile() for a few bytes was blocking the WriteFile() periodically, for unnecessarily long durations.