### PR TITLE
romswitcher: clean up serial output

### DIFF
--- a/romswitcher/main.c
+++ b/romswitcher/main.c
@@ -217,6 +217,7 @@ setup(void)
     serial_putc('K');
     test_draw();
     test_gadget();
+    serial_putc('\r');
     serial_putc('\n');
     BACKGROUND_COLOR(0x999);  // Grey background
 


### PR DESCRIPTION
The \n should be printed on serial in combination with \r, so that
an actual new line is started. Otherwise the output looks like this:

KickSmash ROM Switcher 1.9+ (2026-04-20 23:12:23)

ABCDEFGHIJK
           a4092: a4092.device a4092 42.36-30-g3175767 (21.4.2026)
