### PR TITLE
romswitcher: add Picasso IV flicker fixer support

### DIFF
--- a/romswitcher/Makefile
+++ b/romswitcher/Makefile
@@ -16,7 +16,7 @@ FW	 := ../fw
 MED_SRCS := med_cmds.c mem_access.c med_cmdline.c med_readline.c \
 	    med_cpu.c db_disasm.c
 SRCS     := main.c autoconfig.c cache.c keyboard.c pcmds.c \
-            printf.c reset.c scanf.c screen.c serial.c \
+            picassoiv.c printf.c reset.c scanf.c screen.c serial.c \
             sprite.c strtoll.c strtoull.c timer.c util.c blitter.c \
 	    vectors.c mouse.c draw.c intuition.c gadget.c \
 	    testdraw.c testgadget.c audio.c $(MED_SRCS) \
@@ -133,7 +133,8 @@ $(OBJDIR)/main.o: ../fw/version.c $(filter-out $(OBJDIR)/main.o,$(OBJS))
 $(OBJS): amiga_chipset.h screen.h printf.h util.h serial.h timer.h
 $(OBJDIR)/serial.o: keyboard.h
 $(OBJDIR)/sprite.o: sprite.h
-$(OBJDIR)/main.o: sprite.h keyboard.h reset.h
+$(OBJDIR)/main.o: sprite.h keyboard.h reset.h picassoiv.h
+$(OBJDIR)/picassoiv.o: autoconfig.h picassoiv.h timer.h cache.h
 $(OBJDIR)/draw.o: draw.h intuition.h
 $(OBJDIR)/intuition.o: draw.h intuition.h
 $(OBJDIR)/cache.o $(OBJDIR)/main.o $(OBJDIR)/med_cpu.o: $(AM)/cpu_control.h

--- a/romswitcher/autoconfig.c
+++ b/romswitcher/autoconfig.c
@@ -16,9 +16,11 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "amiga_chipset.h"
+#include "autoconfig.h"
 #include "printf.h"
 #include "util.h"
 #include "med_cmdline.h"
+#include "timer.h"
 
 #define Z2_CFG_BASE 0x00e80000
 #define Z3_CFG_BASE 0xff000000
@@ -30,9 +32,16 @@
 #define Z2_BASE_A19_A16 VADDR8(Z2_CFG_BASE + 0x4a)  // Z2 / Z3 in Z2 space (3)
 #define Z2_BASE_A23_A16 VADDR8(Z2_CFG_BASE + 0x48)  // Z2 / Z3 in Z2 space (4)
 
-#define Z3_BASE_A23_A16 VADDR8(Z3_CFG_BASE + 0x48)  // Z3 in Z3 space (0)
+#define Z3_BASE_A23_A16 VADDR8(Z3_CFG_BASE + 0x48)   // Z3 in Z3 space (0)
+#define Z3_BASE_A19_A16 VADDR8(Z3_CFG_BASE + 0x148)  // Z2 in Z3 space
 #define Z3_BASE_A31_A24 VADDR8(Z3_CFG_BASE + 0x44)  // Z3 in Z3 space (1a)
 #define Z3_BASE_A31_A16 VADDR16(Z3_CFG_BASE + 0x44)  // Z3 in Z3 space (1b)
+
+#define Z2_SLOT_SIZE       (64 << 10)
+#define Z2_MEMORY_START    0x00200000
+#define Z2_MEMORY_END      0x00a00000
+#define Z2_EXPANSION_START 0x00e90000
+#define Z2_EXPANSION_END   0x00f00000
 
 static const char z2_config_sizes[][8] =
 {
@@ -60,13 +69,23 @@ static const char * const config_subsizes[] =
     "4MB", "6MB", "8MB", "10MB", "12MB", "14MB", "Rsvd1", "Rsvd2"
 };
 
+#define AC_ROM_FLAGS     2
+#define AC_FLAG_SIZE_EXT BIT(5)
+
 #define AC_TYPE_INVALID  0
 #define AC_TYPE_ALLOC_Z2 1  // Allocated to Zorro II device
 #define AC_TYPE_ALLOC_Z3 2  // Allocated to Zorro III device
 #define AC_TYPE_FREE_Z2  3  // Free in Zorro II address range
 #define AC_TYPE_FREE_Z3  4  // Free in Zorro III address range
 
+#define PRESENT_CHECK 16
+#define AUTOCONFIG_MAX_BOARDS 32
+#define AUTOCONFIG_SETTLE_TRIES 5
+#define AUTOCONFIG_SETTLE_MSEC 2
+
 typedef struct ac_t ac_t;
+typedef struct z2_slot_rule_t z2_slot_rule_t;
+
 struct ac_t {
     ac_t    *ac_next;
     uint8_t  ac_type;
@@ -76,7 +95,152 @@ struct ac_t {
     uint32_t ac_size;
 };
 
+typedef enum {
+    AC_CFG_WINDOW_Z2 = 0,
+    AC_CFG_WINDOW_Z3 = 1,
+} ac_cfg_window_t;
+
+struct z2_slot_rule_t {
+    uint8_t slots;
+    uint8_t offset_slots;
+};
+
+static const z2_slot_rule_t z2_slot_rules[] =
+{
+    { 128, 32 },  // 8 MB
+    {   1,  0 },  // 64 KB
+    {   2,  0 },  // 128 KB
+    {   4,  0 },  // 256 KB
+    {   8,  0 },  // 512 KB
+    {  16,  0 },  // 1 MB
+    {  32,  0 },  // 2 MB
+    {  64, 32 },  // 4 MB
+};
+
 static ac_t *ac_list = NULL;
+
+static void
+autoconfig_dev_export(const ac_t *node, autoconfig_dev_t *dev)
+{
+    dev->ac_type = node->ac_type;
+    dev->ac_product = node->ac_product;
+    dev->ac_mfg = node->ac_mfg;
+    dev->ac_addr = node->ac_addr;
+    dev->ac_size = node->ac_size;
+}
+
+static uint32_t
+autoconfig_align_up(uint32_t addr, uint32_t align, uint32_t offset)
+{
+    if (addr <= offset)
+        return (offset);
+    return (((addr - offset + align - 1) & ~(align - 1)) + offset);
+}
+
+static bool
+autoconfig_addr_aligned(uint32_t addr, uint32_t align, uint32_t offset)
+{
+    return ((addr >= offset) && (((addr - offset) & (align - 1)) == 0));
+}
+
+/*
+ * autoconfig_alloc_aligned_range
+ * ------------------------------
+ * Allocate a Zorro address in the specified address space with an alignment
+ * rule matching AmigaOS expansion.library slot allocation.
+ */
+static ac_t *
+autoconfig_alloc_aligned_range(uint32_t addr, uint32_t size, uint zorro_type,
+                               uint32_t align, uint32_t offset,
+                               uint32_t range_start, uint32_t range_end,
+                               bool report_failure)
+{
+    ac_t *cur;
+    uint alloc_type = (zorro_type == AC_TYPE_FREE_Z2) ?
+                      AC_TYPE_ALLOC_Z2 : AC_TYPE_ALLOC_Z3;
+
+    if ((addr != 0) && !autoconfig_addr_aligned(addr, align, offset)) {
+        if (report_failure) {
+            printf("Address %08x not aligned to device size %08x; try %08x\n",
+                   addr, align, autoconfig_align_up(addr, align, offset));
+        }
+        return (NULL);
+    }
+
+    for (cur = ac_list; cur != NULL; cur = cur->ac_next) {
+        uint32_t alloc_addr;
+        uint32_t before_size;
+        uint32_t after_size;
+        uint32_t cur_end;
+        uint32_t usable_start;
+        uint32_t usable_end;
+        ac_t *alloc_node = NULL;
+        ac_t *after_node = NULL;
+
+        if (cur->ac_type != zorro_type)
+            continue;  // Not free
+
+        cur_end = cur->ac_addr + cur->ac_size;
+        usable_start = (cur->ac_addr > range_start) ? cur->ac_addr : range_start;
+        usable_end = (cur_end < range_end) ? cur_end : range_end;
+
+        if ((usable_end <= usable_start) || (size > usable_end - usable_start))
+            continue;
+
+        if (addr == 0)
+            alloc_addr = autoconfig_align_up(usable_start, align, offset);
+        else
+            alloc_addr = addr;
+
+        if ((alloc_addr < usable_start) || (size > usable_end - alloc_addr))
+            continue;  // Not within this range
+
+        before_size = alloc_addr - cur->ac_addr;
+        after_size  = cur_end - (alloc_addr + size);
+
+        if (before_size != 0) {
+            alloc_node = malloc(sizeof (ac_t));
+            if (alloc_node == NULL)
+                return (NULL);
+        }
+        if (after_size != 0) {
+            after_node = malloc(sizeof (ac_t));
+            if (after_node == NULL)
+                return (NULL);
+        }
+
+        if (before_size != 0) {
+            alloc_node->ac_type = alloc_type;
+            alloc_node->ac_size = size;
+            alloc_node->ac_addr = alloc_addr;
+            alloc_node->ac_next = cur->ac_next;
+
+            cur->ac_size = before_size;
+            cur->ac_next = alloc_node;
+            cur = alloc_node;
+        } else {
+            cur->ac_type = alloc_type;
+            cur->ac_size = size;
+            cur->ac_addr = alloc_addr;
+        }
+
+        if (after_size != 0) {
+            after_node->ac_type = zorro_type;
+            after_node->ac_size = after_size;
+            after_node->ac_addr = alloc_addr + size;
+            after_node->ac_next = cur->ac_next;
+            cur->ac_next = after_node;
+        }
+        return (cur);
+    }
+    if (report_failure) {
+        printf("Could not allocate");
+        if (addr != 0)
+            printf(" %08x", addr);
+        printf(" in %s space\n", (zorro_type == AC_TYPE_FREE_Z2) ? "Z2" : "Z3");
+    }
+    return (NULL);
+}
 
 /*
  * autoconfig_alloc
@@ -84,55 +248,57 @@ static ac_t *ac_list = NULL;
  * Allocate a Zorro address in the specified address space
  */
 static ac_t *
-autoconfig_alloc(uint addr, uint size, uint zorro_type)
+autoconfig_alloc(uint32_t addr, uint32_t size, uint zorro_type)
 {
-    ac_t *cur;
-    for (cur = ac_list; cur != NULL; cur = cur->ac_next) {
-        if (cur->ac_type != zorro_type)
-            continue;  // Not free
+    return (autoconfig_alloc_aligned_range(addr, size, zorro_type, size, 0,
+                                           0, UINT32_MAX, true));
+}
 
-        if (cur->ac_size < size)
-            continue;
+static ac_t *
+autoconfig_alloc_z2(uint32_t addr, uint size_code)
+{
+    const z2_slot_rule_t *rule;
+    uint32_t size;
+    uint32_t offset;
+    ac_t *node;
 
-        if ((addr != 0) &&
-            ((cur->ac_addr > addr) ||
-             (cur->ac_addr + cur->ac_size < addr + size)))
-            continue;  // Not within this range
+    if (size_code >= (sizeof (z2_slot_rules) / sizeof (z2_slot_rules[0])))
+        return (NULL);
 
-        if ((addr != 0) && (addr > cur->ac_addr)) {
-            /* Fragment this entry (request is inside entry) */
-            uint frag_size = addr - cur->ac_addr;
-            ac_t *node = malloc(sizeof (ac_t));
-            node->ac_type = cur->ac_type;
-            node->ac_size = frag_size;
-            node->ac_addr = addr;
-            node->ac_next = cur->ac_next;
+    rule = &z2_slot_rules[size_code];
+    size = rule->slots * Z2_SLOT_SIZE;
+    offset = rule->offset_slots * Z2_SLOT_SIZE;
 
-            cur->ac_size = cur->ac_size - frag_size;
-            cur->ac_next = node;
-            cur = node;
-        }
-        if (cur->ac_size >= size + 0x10000) {
-            /* Fragment this entry (request is at start of entry) */
-            ac_t *node = malloc(sizeof (ac_t));
-            node->ac_type = cur->ac_type;
-            node->ac_size = cur->ac_size - size;
-            node->ac_addr = cur->ac_addr + size;
-            node->ac_next = cur->ac_next;
-            cur->ac_next = node;
-        }
-        cur->ac_size = size;
-        if (zorro_type == AC_TYPE_FREE_Z2)
-            cur->ac_type = AC_TYPE_ALLOC_Z2;
-        else
-            cur->ac_type = AC_TYPE_ALLOC_Z3;
-        return (cur);
+    if (addr != 0) {
+        return (autoconfig_alloc_aligned_range(addr, size, AC_TYPE_FREE_Z2,
+                                               size, offset, 0, UINT32_MAX,
+                                               true));
     }
-    printf("Could not allocate");
-    if (addr != 0)
-        printf(" %08x", addr);
-    printf(" in %s space\n", (zorro_type == AC_TYPE_FREE_Z2) ? "Z2" : "Z3");
-    return (NULL);
+
+    if (rule->slots <= 4) {
+        node = autoconfig_alloc_aligned_range(0, size, AC_TYPE_FREE_Z2,
+                                              size, offset,
+                                              Z2_EXPANSION_START,
+                                              Z2_EXPANSION_END, false);
+        if (node != NULL)
+            return (node);
+    }
+
+    return (autoconfig_alloc_aligned_range(0, size, AC_TYPE_FREE_Z2,
+                                           size, offset,
+                                           Z2_MEMORY_START, Z2_MEMORY_END,
+                                           true));
+}
+
+static ac_t *
+autoconfig_alloc_board(uint32_t addr, uint32_t devsize, uint size_code,
+                       uint is_z3, uint is_z3_size, uint addr_z3)
+{
+    if (!addr_z3 && !is_z3 && !is_z3_size)
+        return (autoconfig_alloc_z2(addr, size_code));
+
+    return (autoconfig_alloc(addr, devsize,
+                             addr_z3 ? AC_TYPE_FREE_Z3 : AC_TYPE_FREE_Z2));
 }
 
 /*
@@ -171,8 +337,8 @@ autoconfig_list(void)
 static uint8_t
 get_z2_byte(uint offset)
 {
-    uint8_t unibble = (*ADDR16(Z2_CFG_BASE + offset * 4 + 0) >> 8) & 0xf0;
-    uint8_t lnibble = (*ADDR16(Z2_CFG_BASE + offset * 4 + 2) >> 12) & 0x0f;
+    uint8_t unibble = (*VADDR16(Z2_CFG_BASE + offset * 4 + 0) >> 8) & 0xf0;
+    uint8_t lnibble = (*VADDR16(Z2_CFG_BASE + offset * 4 + 2) >> 12) & 0x0f;
     return (unibble | lnibble);
 }
 
@@ -184,9 +350,119 @@ get_z2_byte(uint offset)
 static uint8_t
 get_z3_byte(uint offset)
 {
-    uint8_t unibble = (*ADDR16(Z3_CFG_BASE + offset * 4 + 0x000) >> 8) & 0xf0;
-    uint8_t lnibble = (*ADDR16(Z3_CFG_BASE + offset * 4 + 0x100) >> 12) & 0x0f;
+    uint8_t unibble = (*VADDR16(Z3_CFG_BASE + offset * 4 + 0x000) >> 8) & 0xf0;
+    uint8_t lnibble = (*VADDR16(Z3_CFG_BASE + offset * 4 + 0x100) >> 12) & 0x0f;
     return (unibble | lnibble);
+}
+
+static uint8_t
+autoconfig_window_byte(ac_cfg_window_t cfg_window, uint offset)
+{
+    return ((cfg_window == AC_CFG_WINDOW_Z3) ?
+            get_z3_byte(offset) : get_z2_byte(offset));
+}
+
+static void
+autoconfig_signature_read(ac_cfg_window_t cfg_window,
+                          uint8_t sig[PRESENT_CHECK])
+{
+    uint cur;
+
+    for (cur = 0; cur < PRESENT_CHECK; cur++)
+        sig[cur] = autoconfig_window_byte(cfg_window, cur);
+}
+
+static bool
+autoconfig_signature_same(ac_cfg_window_t cfg_window,
+                          const uint8_t before[PRESENT_CHECK])
+{
+    uint cur;
+    uint all_zero = 1;
+    uint all_ff = 1;
+
+    for (cur = 0; cur < PRESENT_CHECK; cur++) {
+        uint8_t value = autoconfig_window_byte(cfg_window, cur);
+
+        if (value != 0x00)
+            all_zero = 0;
+        if (value != 0xff)
+            all_ff = 0;
+        if (value != before[cur])
+            return (false);
+    }
+
+    return (!all_zero && !all_ff);
+}
+
+static void
+autoconfig_shutup_window(ac_cfg_window_t cfg_window)
+{
+    if (cfg_window == AC_CFG_WINDOW_Z3)
+        *Z3_SHUTUP = 0;
+    else
+        *Z2_SHUTUP = 0;
+}
+
+static bool
+autoconfig_advance_if_still_visible(ac_cfg_window_t cfg_window,
+                                    const uint8_t before[PRESENT_CHECK])
+{
+    uint tries;
+
+    for (tries = 0; tries < AUTOCONFIG_SETTLE_TRIES; tries++) {
+        if (!autoconfig_signature_same(cfg_window, before))
+            return (true);
+        timer_delay_msec(AUTOCONFIG_SETTLE_MSEC);
+    }
+
+    if (!autoconfig_signature_same(cfg_window, before))
+        return (true);
+
+    printf("Z%c config window still has same card after assignment; "
+           "sending shutup\n",
+           (cfg_window == AC_CFG_WINDOW_Z3) ? '3' : '2');
+    autoconfig_shutup_window(cfg_window);
+
+    for (tries = 0; tries < AUTOCONFIG_SETTLE_TRIES; tries++) {
+        timer_delay_msec(AUTOCONFIG_SETTLE_MSEC);
+        if (!autoconfig_signature_same(cfg_window, before))
+            return (true);
+    }
+
+    printf("Z%c config window still has same card after shutup\n",
+           (cfg_window == AC_CFG_WINDOW_Z3) ? '3' : '2');
+    return (false);
+}
+
+static void
+autoconfig_write_base(ac_cfg_window_t cfg_window, uint32_t addr,
+                      uint use_z3_assignment)
+{
+    if (cfg_window == AC_CFG_WINDOW_Z3) {
+        (void) use_z3_assignment;
+
+        /*
+         * Zorro III config-space assignment is committed by writing register
+         * 0x44.  This applies even when the decoded board will live in Zorro
+         * II address space, as on systems that expose Z2 cards through the
+         * Z3 config aperture.
+         */
+        *Z3_BASE_A19_A16 = (addr >> 12);  // Nibble
+        *Z3_BASE_A23_A16 = (addr >> 16);  // Byte
+        *Z3_BASE_A31_A16 = (addr >> 16);  // Word
+    } else {
+        if (use_z3_assignment) {
+            /* Zorro III assignment in the Zorro II config aperture. */
+            *Z2_BASE_A27_A24 = (addr >> 20);  // Nibble
+            *Z2_BASE_A31_A24 = (addr >> 24);  // Byte
+            *Z2_BASE_A19_A16 = (addr >> 12);  // Nibble
+            *Z2_BASE_A23_A16 = (addr >> 16);  // Byte
+        } else {
+            /* Zorro II assignment in the Zorro II config aperture. */
+            *Z2_BASE_A19_A16 = (addr >> 12);  // Nibble
+            *Z2_BASE_A23_A16 = (addr >> 16);  // Byte
+        }
+    }
 }
 
 static void
@@ -271,7 +547,7 @@ autoconfig_decode(uint8_t *cfgdata, uint cfgsize)
     }
     if (value & BIT(5))
         printf(" Memory");
-    if (is_z3 && ((~cfgdata[0x00]) & BIT(5)))
+    if (cfgdata[AC_ROM_FLAGS] & AC_FLAG_SIZE_EXT)
         winsize = z3_config_sizes[value & 0x7];
     else
         winsize = z2_config_sizes[value & 0x7];
@@ -349,7 +625,6 @@ autoconfig_decode(uint8_t *cfgdata, uint cfgsize)
     return (RC_SUCCESS);
 }
 
-#define PRESENT_CHECK 16
 static uint
 z2_is_present(void)
 {
@@ -417,17 +692,15 @@ autoconfig_show(void)
 rc_t
 autoconfig_shutup(void)
 {
-    /* Try Zorro II first */
-    if (z2_is_present()) {
-        printf("Telling ZII to shut up\n");
-        *Z2_SHUTUP = 0;
-        return (RC_SUCCESS);
-    }
-
-    /* Try Zorro III */
     if (z3_is_present()) {
         printf("Telling ZIII to shut up\n");
         *Z3_SHUTUP = 0;
+        return (RC_SUCCESS);
+    }
+
+    if (z2_is_present()) {
+        printf("Telling ZII to shut up\n");
+        *Z2_SHUTUP = 0;
         return (RC_SUCCESS);
     }
     return (RC_NO_DATA);
@@ -458,10 +731,14 @@ static rc_t
 autoconfig_z2_address(uint32_t addr)
 {
     uint8_t  cfg0       = get_z2_byte(0);
-    uint     is_z3_size = cfg0 & BIT(5);
+    uint8_t  cfgflags   = ~get_z2_byte(AC_ROM_FLAGS);
+    uint     is_z3_size = cfgflags & AC_FLAG_SIZE_EXT;
     uint     is_z3 = 0;
     uint     addr_z3 = 0;
     uint32_t devsize;
+    uint8_t  signature[PRESENT_CHECK];
+
+    autoconfig_signature_read(AC_CFG_WINDOW_Z2, signature);
 
     switch (cfg0 >> 6) {
         case 2:  // Zorro III
@@ -476,55 +753,58 @@ autoconfig_z2_address(uint32_t addr)
     }
 
     /* Confirm that the address is allowed based on the board config */
-    if (is_z3 && is_z3_size)
+    if (is_z3_size)
         devsize = z3_config_sizenums[cfg0 & 0x7];
     else
         devsize = z2_config_sizenums[cfg0 & 0x7];
+    if (devsize == 0) {
+        printf("Invalid board size (%x) detected for Zorro II\n", cfg0);
+        return (RC_FAILURE);
+    }
 
     if (addr == 0)
-        addr_z3 = is_z3;
+        addr_z3 = is_z3 || is_z3_size;
     else if (addr >= 0x10000000)
         addr_z3 = 1;
     else
         addr_z3 = 0;
 
-    ac_t *node = autoconfig_alloc(addr, devsize,
-                                  addr_z3 ? AC_TYPE_FREE_Z3 : AC_TYPE_FREE_Z2);
+    ac_t *node = autoconfig_alloc_board(addr, devsize, cfg0 & 0x7,
+                                        is_z3, is_z3_size, addr_z3);
     if (node == NULL)
         return (RC_BAD_PARAM);
     addr = node->ac_addr;
 
-    if (addr & (devsize - 1)) {
-        printf("Address %08x not aligned to device size %08x; try %08x\n",
-               addr, devsize, (addr + devsize - 1) & ~(devsize - 1));
-        return (RC_BAD_PARAM);
-    }
-
     autoconfig_assign(node, 0);
-    if (is_z3) {
-        *Z2_BASE_A27_A24 = (addr >> 20);  // Nibble
-        *Z2_BASE_A31_A24 = (addr >> 24);  // Byte
-        *Z2_BASE_A19_A16 = (addr >> 12);  // Nibble
-        *Z2_BASE_A23_A16 = (addr >> 16);  // Byte
-    } else {
-        *Z2_BASE_A19_A16 = (addr >> 12);  // Nibble
-        *Z2_BASE_A23_A16 = (addr >> 16);  // Byte
-    }
+    autoconfig_write_base(AC_CFG_WINDOW_Z2, addr, is_z3 || addr_z3);
     show_autoconfig(node);
-    return (RC_SUCCESS);
+    return (autoconfig_advance_if_still_visible(AC_CFG_WINDOW_Z2, signature) ?
+            RC_SUCCESS : RC_FAILURE);
 }
 
 static rc_t
 autoconfig_z3_address(uint32_t addr)
 {
     uint8_t  cfg0       = get_z3_byte(0);
-    uint     is_z3_size = cfg0 & BIT(5);
+    uint8_t  cfgflags   = ~get_z3_byte(AC_ROM_FLAGS);
+    uint     is_z3_size = cfgflags & AC_FLAG_SIZE_EXT;
+    uint     is_z3 = 0;
     uint     addr_z3 = 0;
     uint32_t devsize;
+    uint8_t  signature[PRESENT_CHECK];
 
-    if ((cfg0 >> 6) != 2) {
-        printf("Invalid board (%x) detected for Zorro III\n", cfg0);
-        return (RC_FAILURE);
+    autoconfig_signature_read(AC_CFG_WINDOW_Z3, signature);
+
+    switch (cfg0 >> 6) {
+        case 2:  // Zorro III
+            is_z3 = 1;
+            break;
+        case 3:  // Zorro II, visible in Zorro III config space
+            is_z3 = 0;
+            break;
+        default:
+            printf("Invalid board (%x) detected for Zorro III\n", cfg0);
+            return (RC_FAILURE);
     }
 
     /* Confirm that the address is allowed based on the board config */
@@ -532,54 +812,106 @@ autoconfig_z3_address(uint32_t addr)
         devsize = z3_config_sizenums[cfg0 & 0x7];
     else
         devsize = z2_config_sizenums[cfg0 & 0x7];
+    if (devsize == 0) {
+        printf("Invalid board size (%x) detected for Zorro III\n", cfg0);
+        return (RC_FAILURE);
+    }
 
     if (addr == 0)
-        addr_z3 = 1;  // Assume Zorro III
+        addr_z3 = is_z3 || is_z3_size;
     else if (addr >= 0x10000000)
         addr_z3 = 1;
     else
         addr_z3 = 0;
 
-    ac_t *node = autoconfig_alloc(addr, devsize,
-                                  addr_z3 ? AC_TYPE_FREE_Z3 : AC_TYPE_FREE_Z2);
+    ac_t *node = autoconfig_alloc_board(addr, devsize, cfg0 & 0x7,
+                                        is_z3, is_z3_size, addr_z3);
 
     if (node == NULL)
         return (RC_BAD_PARAM);
     addr = node->ac_addr;
 
-    if (addr & (devsize - 1)) {
-        printf("Address %08x not aligned to device size %08x; try %08x\n",
-               addr, devsize, (addr + devsize - 1) & ~(devsize - 1));
-        return (RC_BAD_PARAM);
-    }
-
     autoconfig_assign(node, 1);
 
-#undef CONFIG_Z3_FROM_Z2
-#ifdef CONFIG_Z3_FROM_Z2
-    /* Config in Z2 space */
-    *Z2_BASE_A27_A24 = (addr >> 20);  // Nibble
-    *Z2_BASE_A31_A24 = (addr >> 24);  // Byte
-    *Z2_BASE_A23_A16 = (addr >> 16);  // Nibble
-    *Z2_BASE_A23_A16 = (addr >> 16);  // Byte
-#else
-    /* Config in Z3 space, as specified in the hardware reference manual */
-    *Z3_BASE_A23_A16 = (addr >> 16);  // Byte
-    *Z3_BASE_A31_A16 = (addr >> 16);  // Word
-#endif
+    autoconfig_write_base(AC_CFG_WINDOW_Z3, addr, is_z3 || addr_z3);
     show_autoconfig(node);
-    return (RC_SUCCESS);
+    return (autoconfig_advance_if_still_visible(AC_CFG_WINDOW_Z3, signature) ?
+            RC_SUCCESS : RC_FAILURE);
 }
 
 rc_t
 autoconfig_address(uint32_t addr)
 {
-    /* Dynamically allocate an address based on the board type */
-    if (z3_is_present())
+    if ((addr >= 0x10000000) && (addr < 0x80000000))
         return (autoconfig_z3_address(addr));
-    if (z2_is_present())
+    if (((addr >= 0x00200000) && (addr < 0x00a00000)) ||
+        ((addr >= 0x00e90000) && (addr < 0x00f00000)))
         return (autoconfig_z2_address(addr));
+    if (addr != 0) {
+        printf("0x%08x is not a valid Zorro address\n", addr);
+        return (RC_BAD_PARAM);
+    }
+
+    /*
+     * Match Kickstart's dynamic probe order: the Zorro III config aperture
+     * is checked first. Zorro II cards that legally appear there are still
+     * assigned to Zorro II address space based on their decoded type/size.
+     */
+    if (z3_is_present())
+        return (autoconfig_z3_address(0));
+    if (z2_is_present())
+        return (autoconfig_z2_address(0));
+
     return (RC_NO_DATA);
+}
+
+/*
+ * autoconfig_configure_all
+ * ------------------------
+ * Assign addresses to all devices currently visible through the autoconfig
+ * chain. Devices must be configured to make their normal register windows
+ * accessible.
+ */
+uint
+autoconfig_configure_all(void)
+{
+    uint count = 0;
+    rc_t rc;
+
+    while ((rc = autoconfig_address(0)) == RC_SUCCESS) {
+        count++;
+        if (count >= AUTOCONFIG_MAX_BOARDS) {
+            printf("Autoconfig stopped after %u boards; "
+                   "current card may not be accepting assignment\n", count);
+            break;
+        }
+    }
+    if ((rc != RC_NO_DATA) && (count == 0))
+        printf("Autoconfig stopped with rc=%d\n", rc);
+    return (count);
+}
+
+/*
+ * autoconfig_find
+ * ---------------
+ * Find a configured board by manufacturer and product id.
+ */
+bool
+autoconfig_find(uint16_t mfg, uint8_t product, autoconfig_dev_t *dev)
+{
+    ac_t *cur;
+
+    for (cur = ac_list; cur != NULL; cur = cur->ac_next) {
+        if ((cur->ac_type != AC_TYPE_ALLOC_Z2) &&
+            (cur->ac_type != AC_TYPE_ALLOC_Z3))
+            continue;
+        if ((cur->ac_mfg != mfg) || (cur->ac_product != product))
+            continue;
+        if (dev != NULL)
+            autoconfig_dev_export(cur, dev);
+        return (true);
+    }
+    return (false);
 }
 
 static void

--- a/romswitcher/autoconfig.h
+++ b/romswitcher/autoconfig.h
@@ -16,9 +16,23 @@
 #ifndef _AUTOCONFIG_H
 #define _AUTOCONFIG_H
 
+#include <stdbool.h>
+#include <stdint.h>
+#include "med_cmdline.h"
+
+typedef struct {
+    uint8_t  ac_type;
+    uint8_t  ac_product;
+    uint16_t ac_mfg;
+    uint32_t ac_addr;
+    uint32_t ac_size;
+} autoconfig_dev_t;
+
 void autoconfig_init(void);
 void autoconfig_list(void);
 rc_t autoconfig_address(uint32_t addr);
+uint autoconfig_configure_all(void);
+bool autoconfig_find(uint16_t mfg, uint8_t product, autoconfig_dev_t *dev);
 rc_t autoconfig_shutup(void);
 rc_t autoconfig_show(void);
 

--- a/romswitcher/cache.c
+++ b/romswitcher/cache.c
@@ -26,9 +26,15 @@
 #define CACR_68030_CI  BIT(3)  // Clear instruction cache
 #define CACR_68030_EI  BIT(0)  // Enable instruction cache
 
-#define TTR_E     BIT(15)       // Enable transparent translation
-#define TTR_S_I   BIT(14)       // Supervisor mode -- Ignore
-#define TTR_CM_NC BIT(6)|BIT(5) // Cache mode -- Noncachable
+#define TTR_LBASE(addr) ((uint32_t) (addr) & 0xff000000)
+#define TTR_LMASK(mask) (((uint32_t) (mask) & 0xff) << 16)
+#define TTR_E           BIT(15)       // Enable transparent translation
+#define TTR_S_I         BIT(14)       // Supervisor mode -- Ignore
+#define TTR_CM_NC       (BIT(6) | BIT(5)) // Cache mode -- Noncachable
+#define TTR_NC_RANGE(addr, mask) \
+    (TTR_LBASE(addr) | TTR_LMASK(mask) | TTR_E | TTR_S_I | TTR_CM_NC)
+#define TTR_NC_16M(addr) \
+    TTR_NC_RANGE(addr, 0)
 
 static uint32_t
 convert_030_cacr_to_040_cacr(uint32_t cacr_030)
@@ -97,6 +103,19 @@ CacheControl(uint32_t cache_bits, uint32_t cache_mask)
 }
 
 void
+cache_data_noncache_16m(uint32_t addr)
+{
+    switch (cpu_type) {
+        case 68040:
+        case 68060:
+            cpu_cache_flush_040_data();
+            cpu_set_dtt1(TTR_NC_16M(addr));
+            flush_tlb_040();
+            break;
+    }
+}
+
+void
 cache_init(void)
 {
     switch (cpu_type) {
@@ -113,7 +132,8 @@ cache_init(void)
         case 68060:
             flush_tlb_040();
             cpu_cache_invalidate_040();
-            cpu_set_dtt0(TTR_E | TTR_S_I | TTR_CM_NC);  // Don't cache I/O
+            cpu_set_dtt0(TTR_NC_16M(0x00000000));  // Chipset and Z2 config
+            cpu_set_dtt1(TTR_NC_16M(0xff000000));  // Z3 config
             if (cpu_type == 68060)
                 cpu_set_cacr(CACR_68060_CABC);
             cpu_set_cacr(CACR_68040_EDC | CACR_68040_EIC);

--- a/romswitcher/cache.h
+++ b/romswitcher/cache.h
@@ -30,5 +30,6 @@
 uint32_t CacheControl(uint32_t cache_bits, uint32_t cache_mask);
 
 void cache_init(void);
+void cache_data_noncache_16m(uint32_t addr);
 
 #endif /* _CACHE_H */

--- a/romswitcher/main.c
+++ b/romswitcher/main.c
@@ -24,6 +24,7 @@
 #include "cpu_control.h"
 #include "mouse.h"
 #include "autoconfig.h"
+#include "picassoiv.h"
 #include "testdraw.h"
 #include "testgadget.h"
 #include "printf.h"
@@ -195,11 +196,11 @@ setup(void)
 //  show_string(RomID + 6);
 
     timer_init();
+    serial_init();  // Now that ECLK is known
     serial_putc('D');
     audio_init();
     serial_putc('E');
     BACKGROUND_COLOR(0x008);  // Half Blue background
-//  serial_init();  // Now that ECLK is known
     serial_putc('F');
     keyboard_init();
     serial_putc('G');
@@ -208,7 +209,12 @@ setup(void)
     BACKGROUND_COLOR(0x004);  // Midnight Blue background
     sprite_init();
     serial_putc('I');
+    screen_output_set(0);
+    printf("\n");
     autoconfig_init();
+    autoconfig_configure_all();
+    picassoiv_enable_flicker_fixer();
+    screen_output_set(1);
     serial_putc('J');
 
     gui_wants_all_input = 1;

--- a/romswitcher/picassoiv.c
+++ b/romswitcher/picassoiv.c
@@ -1,0 +1,730 @@
+/*
+ * Village Tronic Picasso IV initialization helpers.
+ *
+ * This source file is part of the code base for a simple Amiga ROM
+ * replacement sufficient to allow programs using some parts of GadTools
+ * to function.
+ *
+ * Copyright 2025 Chris Hooper. This program and source may be used
+ * and distributed freely, for any purpose which benefits the Amiga
+ * community. All redistributions must retain this Copyright notice.
+ *
+ * DISCLAIMER: THE SOFTWARE IS PROVIDED "AS-IS", WITHOUT ANY WARRANTY.
+ * THE AUTHOR ASSUMES NO LIABILITY FOR ANY DAMAGE ARISING OUT OF THE USE
+ * OR MISUSE OF THIS UTILITY OR INFORMATION REPORTED BY THIS UTILITY.
+ */
+#include <stdint.h>
+#include "amiga_chipset.h"
+#include "autoconfig.h"
+#include "picassoiv.h"
+#include "printf.h"
+#include "timer.h"
+#include "util.h"
+#include "cache.h"
+
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(x) (sizeof (x) / sizeof ((x)[0]))
+#endif
+
+#define PICASSOIV_MFG          0x0877
+#define PICASSOIV_PRODUCT_Z2FF 0x17
+#define PICASSOIV_PRODUCT_Z3FF 0x18
+#define P4_RGB_LOAD_NIBBLE     0x0f
+
+typedef struct {
+    uint32_t control_base;
+    uint32_t regs_base;
+    uint32_t post_base;
+    uint32_t mem_base;
+    uint8_t  variant;
+    uint8_t  seq0f_18;
+    uint8_t  product;
+} p4_ff_t;
+
+static const uint16_t p4_ff_pal[12] = {
+    0x1c1c, 0x02f8, 0x030c, 0x0370, 0x0398, 0x025b,
+    0x025c, 0x025e, 0x0271, 0x0310, 0x0270, 0x0000,
+};
+
+static const uint16_t p4_ff_ntsc[12] = {
+    0x1c1c, 0x02f8, 0x0310, 0x0370, 0x0398, 0x01e9,
+    0x01f0, 0x01f4, 0x020d, 0x0310, 0x01ea, 0x0000,
+};
+
+static void
+p4_delay(void)
+{
+    (void) *CIAA_PRA;
+}
+
+static void
+p4_delay_count(uint count)
+{
+    while (count-- != 0)
+        p4_delay();
+}
+
+static void
+p4_index_write(volatile uint8_t *regs, uint port, uint8_t idx, uint8_t value)
+{
+    *VADDR16((uintptr_t) regs + port) = (((uint16_t) idx) << 8) | value;
+    p4_delay();
+}
+
+static uint8_t
+crtc_read(volatile uint8_t *regs, uint8_t idx)
+{
+    regs[0x3d4] = idx;
+    p4_delay();
+    return (regs[0x3d5]);
+}
+
+static void
+crtc_write(volatile uint8_t *regs, uint8_t idx, uint8_t value)
+{
+    p4_index_write(regs, 0x3d4, idx, value);
+}
+
+static void
+crtc_set(volatile uint8_t *regs, uint8_t idx, uint8_t bits)
+{
+    crtc_write(regs, idx, crtc_read(regs, idx) | bits);
+}
+
+static void
+crtc_clear(volatile uint8_t *regs, uint8_t idx, uint8_t bits)
+{
+    crtc_write(regs, idx, crtc_read(regs, idx) & (uint8_t) ~bits);
+}
+
+static uint8_t
+seq_read(volatile uint8_t *regs, uint8_t idx)
+{
+    regs[0x3c4] = idx;
+    p4_delay();
+    return (regs[0x3c5]);
+}
+
+static void
+seq_write(volatile uint8_t *regs, uint8_t idx, uint8_t value)
+{
+    p4_index_write(regs, 0x3c4, idx, value);
+}
+
+static void
+gc_write(volatile uint8_t *regs, uint8_t idx, uint8_t value)
+{
+    p4_index_write(regs, 0x3ce, idx, value);
+}
+
+static void
+p4_wait_input_status(volatile uint8_t *regs, uint8_t bit_set)
+{
+    uint timeout;
+
+    for (timeout = 0; timeout < 2000; timeout++) {
+        if (((regs[0x3da] & 0x01) != 0) == bit_set)
+            return;
+        p4_delay();
+    }
+}
+
+static void
+p4_dac_hidden_read4(volatile uint8_t *regs)
+{
+    uint x;
+
+    /*
+     * The S3/RAMDAC hidden command register is selected by four reads from
+     * 0x3c6. Delays alone leave the native-video colour path misprogrammed.
+     */
+    for (x = 0; x < 4; x++) {
+        (void) regs[0x3c6];
+        p4_delay();
+    }
+}
+
+static uint8_t
+p4_ctrl_wait(volatile uint8_t *reg, uint8_t mask, uint8_t expected)
+{
+    uint timeout;
+    uint8_t value = 0;
+
+    for (timeout = 0; timeout < 10000; timeout++) {
+        value = *reg & mask;
+        if (value == expected)
+            return (value);
+        p4_delay();
+    }
+    return (value);
+}
+
+static uint8_t
+p4_control_index_read(const p4_ff_t *ff, uint16_t index)
+{
+    volatile uint8_t *reg;
+
+    reg = VADDR8(ff->control_base + 0x800 + ((uint32_t) index * 2));
+    p4_delay();
+    return (*reg);
+}
+
+static void
+p4_control_index_write(const p4_ff_t *ff, uint16_t index, uint8_t value)
+{
+    volatile uint8_t *reg;
+
+    reg = VADDR8(ff->control_base + 0x800 + ((uint32_t) index * 2));
+    *reg = value;
+    p4_delay();
+}
+
+static void
+p4_program_rgb_loads(const p4_ff_t *ff)
+{
+    uint8_t sig22a;
+    uint8_t stat22e;
+    uint8_t rgb_load;
+    uint ready = 0;
+    uint poll;
+
+    /*
+     * Picasso IV ROM programs these board-side controls
+     * through control_base + 0x800 + index * 2.
+     */
+    p4_control_index_write(ff, 0x226, 0x01);
+    timer_delay_usec(4000);
+    p4_control_index_write(ff, 0x226, 0x00);
+
+    sig22a = 0xff;
+    stat22e = 0xff;
+    for (poll = 0; poll < 100; poll++) {
+        timer_delay_usec(1000);
+        stat22e = p4_control_index_read(ff, 0x22e);
+        sig22a = p4_control_index_read(ff, 0x22a);
+        if (((stat22e & 0x80) != 0) && (sig22a == 0xaa)) {
+            ready = 1;
+            break;
+        }
+    }
+
+    rgb_load = (P4_RGB_LOAD_NIBBLE << 4) | P4_RGB_LOAD_NIBBLE;
+    p4_control_index_write(ff, 0x224, 0x00);
+    p4_control_index_write(ff, 0x225, 0x00);
+    p4_control_index_write(ff, 0x224, 0x3e);
+    p4_control_index_write(ff, 0x225, 0xff);
+    p4_control_index_write(ff, 0x224, 0x36);
+    p4_control_index_write(ff, 0x225, 0x88);
+    p4_control_index_write(ff, 0x224, 0x32);
+    p4_control_index_write(ff, 0x225, rgb_load);
+
+    if (ready)
+        timer_delay_msec(250);
+}
+
+static void
+p4_program_rgb_load_post(const p4_ff_t *ff)
+{
+    /*
+     * ROM re-applies these two control writes for boards connected to the
+     * video slot. Keep this separate from the polled RGB load helper above
+     * because the ROM does the late pass separately.
+     */
+    p4_control_index_write(ff, 0x224, 0x3e);
+    p4_control_index_write(ff, 0x225, 0xff);
+    p4_control_index_write(ff, 0x224, 0x32);
+    p4_control_index_write(ff, 0x225, 0xff);
+}
+
+static void
+p4_video_slot_cmd(const p4_ff_t *ff, uint16_t cmd_index,
+                  uint8_t command, uint8_t value)
+{
+    p4_control_index_write(ff, cmd_index, command);
+    timer_delay_usec(4);
+    p4_control_index_write(ff, cmd_index + 1, value);
+    timer_delay_usec(23);
+}
+
+static void
+p4_program_video_slot_config(const p4_ff_t *ff)
+{
+    /*
+     * ROM programs the video-slot colour path after the RGB load handshake
+     * succeeds.
+     */
+    p4_video_slot_cmd(ff, 0x228, 0x01, 0x00);
+    p4_video_slot_cmd(ff, 0x222, 0x05, 0x01);
+    p4_video_slot_cmd(ff, 0x228, 0xc0, 0x31);
+    p4_video_slot_cmd(ff, 0x228, 0x23, 0x21);
+    p4_video_slot_cmd(ff, 0x228, 0x43, 0x00);
+    p4_video_slot_cmd(ff, 0x228, 0x63, 0xff);
+    p4_video_slot_cmd(ff, 0x228, 0x83, 0x05);
+    p4_video_slot_cmd(ff, 0x228, 0x20, 0x20);
+    p4_video_slot_cmd(ff, 0x228, 0x40, 0x3f);
+    p4_video_slot_cmd(ff, 0x228, 0x60, 0x44);
+    p4_video_slot_cmd(ff, 0x228, 0x80, 0x05);
+    p4_video_slot_cmd(ff, 0x228, 0x23, 0x21);
+    p4_video_slot_cmd(ff, 0x228, 0xa0, 0x40);
+    p4_video_slot_cmd(ff, 0x228, 0xb0, 0x2e);
+    timer_delay_msec(250);
+    p4_video_slot_cmd(ff, 0x228, 0xb0, 0x0e);
+    p4_video_slot_cmd(ff, 0x222, 0x05, 0x00);
+}
+
+static void
+p4_control_cold_init(p4_ff_t *ff)
+{
+    volatile uint8_t *control = VADDR8(ff->control_base);
+    volatile uint8_t *ctrl400 = VADDR8(ff->control_base + 0x400);
+    volatile uint8_t *mem1000 = VADDR8(ff->mem_base + 0x1000);
+    volatile uint8_t *mem0800 = VADDR8(ff->mem_base + 0x0800);
+    uint8_t chip;
+    uint8_t ctrl404;
+    uint8_t revision;
+    uint8_t aa_video = 0;
+
+    control[0] = 0x00;
+    p4_delay();
+    control[0] = 0x00;
+    p4_delay();
+    control[0] = 0x03;
+    p4_delay();
+
+    if (ff->product == PICASSOIV_PRODUCT_Z3FF) {
+        *VADDR32(ff->mem_base + 0x1000 + 0x14) = 0xc1030000;
+        *VADDR32(ff->mem_base + 0x1000 + 0x10) = 0x08000080;
+        *VADDR32(ff->mem_base + 0x1000 + 0x08) = 0x00000003;
+        *VADDR32(ff->mem_base + 0x1000 + 0x04) = 0x03000002;
+    } else {
+        mem1000[0x13] = 0xff;
+        p4_delay();
+        if (mem1000[0x13] != 0xff) {
+            *VADDR32(ff->mem_base + 0x1000 + 0x14) = 0x00800b00;
+            ff->post_base += 0x100;
+        } else {
+            *VADDR32(ff->mem_base + 0x1000 + 0x14) = 0xc0030000;
+        }
+        *VADDR32(ff->mem_base + 0x1000 + 0x10) = 0x00000080;
+        *VADDR32(ff->mem_base + 0x1000 + 0x04) = 0x03000000;
+    }
+
+    *VADDR32(ff->mem_base + 0x0800 + 0x14) = 0x00002080;
+    *VADDR32(ff->mem_base + 0x0800 + 0x10) = 0x00000080;
+    if (ff->product != PICASSOIV_PRODUCT_Z3FF) {
+        *VADDR32(ff->mem_base + 0x0800 + 0x1c) = 0x00000080;
+        *VADDR32(ff->mem_base + 0x0800 + 0x18) = 0x00800b00;
+    }
+
+    chip = mem0800[0x02];
+    if (chip == 0x02)
+        chip = mem0800[0x08];
+
+    control[0] = 0x07;
+    if (chip >= 0x03) {
+        control[0x10] = 0x0c;
+        control[0x14] = 0x0c;
+        control[0x18] = 0x0c;
+        control[0x1c] = 0x0c;
+    }
+
+    ctrl404 = ctrl400[0x04];
+    revision = ctrl404 >> 4;
+    if (ctrl404 & 0x04) {
+        aa_video = 1;
+        if (revision < 4)
+            aa_video = 0;
+    }
+    ff->variant = aa_video;
+
+    ctrl400[0x00] = 0x00;
+    ctrl400[0x06] = 0x03;
+    p4_delay_count(8);
+    (void) p4_ctrl_wait(&ctrl400[0x06], 0x87, 0x87);
+    ctrl400[0x06] = 0x01;
+    p4_delay_count(8);
+    (void) p4_ctrl_wait(&ctrl400[0x06], 0x87, 0x05);
+    ctrl400[0x06] = 0x00;
+    p4_delay_count(8);
+    (void) p4_ctrl_wait(&ctrl400[0x06], 0x87, 0x00);
+    ctrl400[0x06] = 0x02;
+    p4_delay_count(8);
+    (void) p4_ctrl_wait(&ctrl400[0x06], 0x87, 0x82);
+
+    ctrl400[0x06] = 0x00;
+    p4_delay_count(8);
+    ctrl400[0x06] = 0x01;
+    p4_delay_count(8);
+    ctrl400[0x06] = 0x03;
+    p4_delay_count(8);
+}
+
+static void
+p4_unlock_extended(volatile uint8_t *regs)
+{
+    regs[0x3c6] = 0xff;
+    p4_delay_count(8);
+
+    seq_write(regs, 0x08, 0x43);
+    p4_delay_count(8);
+    (void) seq_read(regs, 0x08);
+    seq_write(regs, 0x08, 0x41);
+    p4_delay_count(8);
+    (void) seq_read(regs, 0x08);
+    seq_write(regs, 0x08, 0x40);
+    p4_delay_count(8);
+    (void) seq_read(regs, 0x08);
+    seq_write(regs, 0x08, 0x42);
+    p4_delay_count(8);
+    (void) seq_read(regs, 0x08);
+
+    seq_write(regs, 0x08, 0x40);
+    p4_delay_count(8);
+    seq_write(regs, 0x08, 0x41);
+    p4_delay_count(8);
+    seq_write(regs, 0x08, 0x43);
+    p4_delay_count(8);
+}
+
+static void
+p4_vga_cold_init(const p4_ff_t *ff, volatile uint8_t *regs)
+{
+    static const uint8_t seq_init[][2] = {
+        { 0x06, 0x12 }, { 0x01, 0x01 }, { 0x0f, 0x98 },
+        { 0x00, 0x03 }, { 0x02, 0xff }, { 0x03, 0x00 },
+        { 0x04, 0x0e }, { 0x08, 0x43 }, { 0x16, 0x00 },
+        { 0x18, 0x02 }, { 0x0e, 0x65 }, { 0x1e, 0x3b },
+        { 0x17, 0x04 }, { 0x12, 0x00 }, { 0x13, 0x3c },
+        { 0x1f, 0x2d },
+    };
+    static const uint8_t crtc_init[][2] = {
+        { 0x00, 0x5f }, { 0x01, 0x4f }, { 0x02, 0x50 },
+        { 0x03, 0x82 }, { 0x04, 0x54 }, { 0x05, 0x80 },
+        { 0x06, 0xbf }, { 0x07, 0x1f }, { 0x08, 0x00 },
+        { 0x09, 0xc0 }, { 0x0a, 0x00 }, { 0x0b, 0x00 },
+        { 0x0c, 0x00 }, { 0x0d, 0x00 }, { 0x0e, 0x00 },
+        { 0x0f, 0x00 }, { 0x10, 0x9c }, { 0x11, 0x3e },
+        { 0x12, 0x8f }, { 0x13, 0x50 }, { 0x14, 0x00 },
+        { 0x15, 0x96 }, { 0x16, 0xb9 }, { 0x17, 0xc3 },
+        { 0x18, 0xff }, { 0x19, 0x00 }, { 0x1a, 0x02 },
+        { 0x1b, 0xa2 }, { 0x1c, 0x00 }, { 0x1d, 0x40 },
+        { 0x3e, 0x20 }, { 0x3f, 0x01 }, { 0x50, 0x01 },
+        { 0x51, 0x00 }, { 0x52, 0x00 }, { 0x53, 0x00 },
+        { 0x58, 0x40 }, { 0x5c, 0x00 }, { 0x5d, 0x00 },
+        { 0x5e, 0x00 },
+    };
+    static const uint8_t gc_init[][2] = {
+        { 0x00, 0x00 }, { 0x01, 0x00 }, { 0x02, 0x00 },
+        { 0x03, 0x00 }, { 0x04, 0x00 }, { 0x05, 0x00 },
+        { 0x09, 0x00 }, { 0x0a, 0x00 }, { 0x06, 0x05 },
+        { 0x07, 0x0f }, { 0x08, 0xff }, { 0x0b, 0x28 },
+        { 0x0e, 0x20 }, { 0x31, 0x04 }, { 0x31, 0x80 },
+        { 0x17, 0x0c }, { 0x18, 0x04 }, { 0x19, 0x00 },
+    };
+    static const uint8_t attr_init[][2] = {
+        { 0x30, 0x01 }, { 0x31, 0x00 }, { 0x32, 0x0f },
+        { 0x33, 0x00 }, { 0x34, 0x00 },
+    };
+    uint x;
+
+    regs[0x3c6] = 0xff;
+    regs[0x3c2] = 0x6f;
+    for (x = 0; x < ARRAY_SIZE(seq_init); x++)
+        seq_write(regs, seq_init[x][0], seq_init[x][1]);
+    for (x = 0; x < ARRAY_SIZE(crtc_init); x++)
+        crtc_write(regs, crtc_init[x][0], crtc_init[x][1]);
+    for (x = 0; x < ARRAY_SIZE(gc_init); x++)
+        gc_write(regs, gc_init[x][0], gc_init[x][1]);
+
+    (void) regs[0x3da];
+    for (x = 0; x < 16; x++) {
+        regs[0x3c0] = x;
+        p4_delay();
+        regs[0x3c0] = x;
+        p4_delay();
+    }
+    (void) regs[0x3da];
+    for (x = 0; x < ARRAY_SIZE(attr_init); x++) {
+        regs[0x3c0] = attr_init[x][0];
+        p4_delay();
+        regs[0x3c0] = attr_init[x][1];
+        p4_delay();
+    }
+
+    seq_write(regs, 0x07, 0x21);
+    seq_write(regs, 0x16, 0x00);
+    if (ff->seq0f_18)
+        seq_write(regs, 0x0f, 0x18);
+
+    regs[0x3c6] = 0x00;
+    p4_delay();
+    p4_dac_hidden_read4(regs);
+    regs[0x3c6] = 0x00;
+    p4_delay();
+    regs[0x3c6] = 0x00;
+    p4_delay();
+    p4_wait_input_status(regs, 1);
+    p4_wait_input_status(regs, 0);
+
+    regs[0x3c8] = 0x00;
+    p4_delay();
+    regs[0x3c9] = 0x10;
+    p4_delay();
+    regs[0x3c9] = 0x10;
+    p4_delay();
+    regs[0x3c9] = 0x10;
+    p4_delay();
+    p4_wait_input_status(regs, 1);
+    p4_wait_input_status(regs, 0);
+
+    if ((regs[0x3c2] & 0x10) == 0) {
+        regs[0x3c8] = 0x00;
+        p4_delay();
+        regs[0x3c9] = 0x04;
+        p4_delay();
+        regs[0x3c9] = 0x10;
+        p4_delay();
+        regs[0x3c9] = 0x04;
+        p4_delay();
+        p4_wait_input_status(regs, 1);
+        p4_wait_input_status(regs, 0);
+    }
+
+    p4_unlock_extended(regs);
+}
+
+static void
+p4_program_vga_timing(volatile uint8_t *regs, const uint16_t timing[12],
+                      uint variant)
+{
+    static const uint8_t cfg[2][4] = {
+        { 0x02, 0x01, 0xa0, 0x06 },
+        { 0x03, 0x03, 0xe5, 0x04 },
+    };
+    static const uint8_t crtc_1c[8] = {
+        0x00, 0x20, 0x28, 0x30, 0x38, 0x08, 0x10, 0x18,
+    };
+    const uint8_t *cur_cfg = cfg[variant ? 1 : 0];
+    uint8_t old;
+    uint8_t value;
+    uint x;
+    uint shift;
+
+    regs[0x3c6] = 0xff;
+    crtc_write(regs, 0x14, crtc_read(regs, 0x14) & 0x9f);
+    crtc_write(regs, 0x17, 0xc3);
+    gc_write(regs, 0x05, 0x40);
+
+    old = regs[0x3c6];
+    regs[0x3c6] = 0x00;
+    p4_delay();
+    p4_dac_hidden_read4(regs);
+    regs[0x3c6] = cur_cfg[2];
+    p4_delay();
+    regs[0x3c6] = old;
+    p4_delay();
+
+    seq_write(regs, 0x02, 0xff);
+    seq_write(regs, 0x04, seq_read(regs, 0x04) | 0x08);
+    seq_write(regs, 0x07, seq_read(regs, 0x07) | 0x01);
+
+    x = timing[0];
+    seq_write(regs, 0x1e, x & 0x3f);
+    seq_write(regs, 0x0e, (x >> 8) & 0x7f);
+    seq_write(regs, 0x07, (seq_read(regs, 0x07) & 0xf1) | cur_cfg[3]);
+
+    crtc_write(regs, 0x00, (((timing[4] + 3) >> 3) - 5) & 0xff);
+    value = (crtc_read(regs, 0x1c) & 0x11) | crtc_1c[timing[4] & 7];
+    crtc_write(regs, 0x1c, value);
+    crtc_write(regs, 0x01, (((timing[1] + 7) >> 3) - 1) & 0xff);
+    crtc_write(regs, 0x04, (timing[2] >> 3) & 0xff);
+    crtc_write(regs, 0x1c, timing[2] & 7);
+    value = (crtc_read(regs, 0x05) & 0xe0) | ((timing[3] >> 3) & 0x1f);
+    crtc_write(regs, 0x05, value);
+
+    shift = (timing[11] & 4) >> 2;
+
+    x = (timing[8] >> shift) - 2;
+    crtc_write(regs, 0x06, x & 0xff);
+    value = crtc_read(regs, 0x07) & 0xde;
+    if (x & 0x100)
+        value |= 0x01;
+    if (x & 0x200)
+        value |= 0x20;
+    crtc_write(regs, 0x07, value);
+
+    x = (timing[5] >> shift) - 1;
+    crtc_write(regs, 0x12, x & 0xff);
+    value = crtc_read(regs, 0x07) & 0xbd;
+    if (x & 0x100)
+        value |= 0x02;
+    if (x & 0x200)
+        value |= 0x40;
+    crtc_write(regs, 0x07, value);
+
+    x = (timing[6] >> shift) - 1;
+    crtc_write(regs, 0x10, x & 0xff);
+    value = crtc_read(regs, 0x07) & 0x7b;
+    if (x & 0x100)
+        value |= 0x04;
+    if (x & 0x200)
+        value |= 0x80;
+    crtc_write(regs, 0x07, value);
+
+    x = (timing[7] >> shift) - 1;
+    crtc_write(regs, 0x11, (crtc_read(regs, 0x11) & 0xf0) | (x & 0x0f));
+
+    regs[0x3c2] = ((regs[0x3cc] & 0x2f) | ((timing[11] & 3) << 6)) ^ 0xc0;
+
+    crtc_write(regs, 0x1a, (crtc_read(regs, 0x1a) & 0xfe) | (shift & 1));
+    if (shift != 0)
+        crtc_write(regs, 0x19, crtc_read(regs, 0x04) >> 1);
+
+    x = (timing[1] * cur_cfg[1]) >> cur_cfg[0];
+    crtc_write(regs, 0x13, x & 0xff);
+    crtc_write(regs, 0x1b, (crtc_read(regs, 0x1b) & 0xef) |
+                         ((x >> 4) & 0x10));
+
+    (void) regs[0x3da];
+    regs[0x3c0] = 0x20;
+}
+
+static void
+p4_program_ff_ext(volatile uint8_t *regs, const uint16_t timing[12],
+                  uint capture_mode)
+{
+    uint x;
+    uint8_t value;
+
+    crtc_write(regs, 0x5b, crtc_read(regs, 0x5b) & 0x1f);
+    crtc_write(regs, 0x5d, crtc_read(regs, 0x5d) & 0x33);
+    crtc_write(regs, 0x59, 0x00);
+    crtc_write(regs, 0x5a, 0x00);
+    crtc_write(regs, 0x58, crtc_read(regs, 0x58) & 0x60);
+
+    x = (((capture_mode + 2) * timing[9]) & 0x0fff) >> 3;
+    crtc_write(regs, 0x3d, x & 0xff);
+    value = (crtc_read(regs, 0x3c) & 0x0f) | ((x & 0x100) ? 0x20 : 0x00);
+    crtc_write(regs, 0x3c, value);
+    crtc_write(regs, 0x13, x & 0xff);
+    value = (crtc_read(regs, 0x1b) & 0xef) | ((x & 0x100) ? 0x10 : 0x00);
+    crtc_write(regs, 0x1b, value);
+
+    x = (timing[10] & 0x03ff) >> 1;
+    crtc_write(regs, 0x57, x & 0xff);
+    value = crtc_read(regs, 0x58) & 0x4f;
+    if (x & 0x100)
+        value |= 0x20;
+    crtc_write(regs, 0x58, value);
+
+    crtc_write(regs, 0x5b, 0x00);
+    crtc_write(regs, 0x51, 0x01);
+    crtc_write(regs, 0x56, 0x00);
+    crtc_write(regs, 0x54, 0x00);
+    crtc_write(regs, 0x3e, 0x00);
+    crtc_write(regs, 0x50, capture_mode ? 0x0a : 0x12);
+    crtc_write(regs, 0x51, 0x09);
+}
+
+static void
+p4_post_init(volatile uint32_t *post)
+{
+    post[0] = 0x00000000;
+    post[1] = 0x00000000;
+    post[2] = 0xff0fff03;
+    post[3] = 0x00100010;
+    post[5] = 0x00000000;
+    post[7] = 0x00000000;
+    post[6] = 0x00000000;
+    p4_delay();
+    post[4] = 0x00000000;
+    p4_delay();
+}
+
+static void
+p4_route_native_video(volatile uint8_t *regs)
+{
+    crtc_clear(regs, 0x09, 0x80);
+    crtc_set(regs, 0x50, 0x40);
+}
+
+static void
+p4_enable(const p4_ff_t *ff)
+{
+    p4_ff_t state = *ff;
+    volatile uint8_t *control = VADDR8(state.control_base);
+    volatile uint8_t *regs = VADDR8(state.regs_base);
+    volatile uint32_t *post;
+    const uint16_t *timing;
+    uint capture_mode;
+
+    timing = (vid_type == VID_PAL) ? p4_ff_pal : p4_ff_ntsc;
+    capture_mode = state.variant;
+
+    p4_control_cold_init(&state);
+    p4_program_rgb_loads(&state);
+    p4_program_video_slot_config(&state);
+    p4_vga_cold_init(&state, regs);
+    post = VADDR32(state.post_base);
+
+    p4_post_init(post);
+
+    p4_program_vga_timing(regs, timing, state.variant);
+
+    control[0x404] = (((state.variant ^ 1) << 1) | 1);
+    p4_delay();
+
+    p4_program_ff_ext(regs, timing, capture_mode);
+
+    p4_post_init(post);
+
+    p4_route_native_video(regs);
+    p4_program_rgb_load_post(&state);
+}
+
+static int
+p4_find_ff(p4_ff_t *ff)
+{
+    autoconfig_dev_t dev;
+
+    if (autoconfig_find(PICASSOIV_MFG, PICASSOIV_PRODUCT_Z2FF, &dev)) {
+        ff->control_base = dev.ac_addr;
+        ff->regs_base = dev.ac_addr + 0x00010000;
+        ff->post_base = dev.ac_addr + 0x00008000;
+        ff->mem_base = dev.ac_addr;
+        ff->variant = 0;
+        ff->seq0f_18 = 1;
+        ff->product = dev.ac_product;
+        return (1);
+    }
+
+    if (autoconfig_find(PICASSOIV_MFG, PICASSOIV_PRODUCT_Z3FF, &dev)) {
+        ff->control_base = dev.ac_addr;
+        ff->regs_base = dev.ac_addr + 0x00600000;
+        ff->post_base = dev.ac_addr + 0x00200000;
+        ff->mem_base = dev.ac_addr + 0x00400000;
+        ff->variant = 0;
+        ff->seq0f_18 = 0;
+        ff->product = dev.ac_product;
+        return (1);
+    }
+
+    return (0);
+}
+
+rc_t
+picassoiv_enable_flicker_fixer(void)
+{
+    p4_ff_t ff;
+
+    if (!p4_find_ff(&ff))
+        return (RC_NO_DATA);
+
+    if (ff.control_base >= 0x10000000)
+        cache_data_noncache_16m(ff.control_base);
+
+    printf("PicassoIV flicker fixer: product 0x%02x regs=%08x %s\n",
+           ff.product, ff.regs_base, (vid_type == VID_PAL) ? "PAL" : "NTSC");
+    p4_enable(&ff);
+    return (RC_SUCCESS);
+}

--- a/romswitcher/picassoiv.h
+++ b/romswitcher/picassoiv.h
@@ -1,0 +1,23 @@
+/*
+ * Village Tronic Picasso IV initialization helpers.
+ *
+ * This header file is part of the code base for a simple Amiga ROM
+ * replacement sufficient to allow programs using some parts of GadTools
+ * to function.
+ *
+ * Copyright 2025 Chris Hooper. This program and source may be used
+ * and distributed freely, for any purpose which benefits the Amiga
+ * community. All redistributions must retain this Copyright notice.
+ *
+ * DISCLAIMER: THE SOFTWARE IS PROVIDED "AS-IS", WITHOUT ANY WARRANTY.
+ * THE AUTHOR ASSUMES NO LIABILITY FOR ANY DAMAGE ARISING OUT OF THE USE
+ * OR MISUSE OF THIS UTILITY OR INFORMATION REPORTED BY THIS UTILITY.
+ */
+#ifndef _PICASSOIV_H
+#define _PICASSOIV_H
+
+#include "med_cmdline.h"
+
+rc_t picassoiv_enable_flicker_fixer(void);
+
+#endif /* _PICASSOIV_H */

--- a/romswitcher/screen.h
+++ b/romswitcher/screen.h
@@ -32,6 +32,7 @@
 
 void show_char(uint ch);
 void show_string(const uint8_t *str);
+void screen_output_set(uint enabled);
 void render_text_at(const char *str, uint maxlen, uint x, uint y,
                     uint fg_color, uint bg_color);
 void screen_init(void);

--- a/romswitcher/serial.c
+++ b/romswitcher/serial.c
@@ -34,6 +34,8 @@ volatile uint8_t     gui_wants_all_input; // Non-zero if GUI wants all key input
 static uint8_t       ser_out_wrapped;     // Serial output wrapped buffer
 static uint8_t       ser_out_buf[4096];   // Serial output
 static volatile uint16_t ser_out_prod;    // Serial output producer
+static uint8_t       serial_output_enabled = 1;  // Console text writes serial
+static uint8_t       screen_output_enabled = 1;  // Console text draws to screen
 
 static const uint8_t input_med_magic[] = { 0x0d, 0x05, 0x04,         // ^M^E^D
                                            0x13, 0x14, 0x0f, 0x10 }; // ^S^T^O^P
@@ -129,7 +131,7 @@ serial_init(void)
     *CIAB_PRA = 0x4f; // Set DTR
     *INTENA = INTENA_TBE | INTENA_RBF;  // disable interrupts
     *INTREQ = INTREQ_TBE | INTREQ_RBF;  // clear interrupts
-    *INTENA = INTENA_SETCLR | INTENA_RBF;  // enable interrupt
+    *INTENA = INTENA_SETCLR | INTENA_INTEN | INTENA_RBF;  // enable interrupt
 }
 
 void
@@ -138,7 +140,8 @@ serial_putc(unsigned int ch)
     ser_out_buf[ser_out_prod] = ch;
     ser_out_prod = (ser_out_prod + 1) % sizeof (ser_out_buf);
 
-    if ((serial_active == 0) && (timer_tick_get() >> 25))
+    if ((serial_active == 0) && (eclk_ticks_per_sec != 0) &&
+        (timer_tick_get() >> 25))
         return;  // No serial input and it's past 45 seconds
 
 #if 0
@@ -212,6 +215,18 @@ serial_puts(const char *str)
 }
 
 void
+serial_output_set(uint enabled)
+{
+    serial_output_enabled = (enabled != 0);
+}
+
+void
+screen_output_set(uint enabled)
+{
+    screen_output_enabled = (enabled != 0);
+}
+
+void
 serial_poll(void)
 {
     int ch;
@@ -253,23 +268,31 @@ int
 putchar(int ch)
 {
     if (ch == '\n') {
-        serial_putc('\r');
-        show_char('\r');
+        if (serial_output_enabled)
+            serial_putc('\r');
+        if (screen_output_enabled)
+            show_char('\r');
     }
 
-    serial_putc((uint) ch);
-    show_char((uint) ch);
+    if (serial_output_enabled)
+        serial_putc((uint) ch);
+    if (screen_output_enabled)
+        show_char((uint) ch);
     return (ch);
 }
 
 int
 puts(const char *str)
 {
-    serial_puts(str);
-    serial_putc('\r');
-    serial_putc('\n');
-    show_string(str);
-    show_string("\r\n");
+    if (serial_output_enabled) {
+        serial_puts(str);
+        serial_putc('\r');
+        serial_putc('\n');
+    }
+    if (screen_output_enabled) {
+        show_string(str);
+        show_string("\r\n");
+    }
     return (0);
 }
 

--- a/romswitcher/serial.h
+++ b/romswitcher/serial.h
@@ -19,6 +19,7 @@
 void serial_init(void);
 void serial_putc(unsigned int ch);
 void serial_puts(const char *str);
+void serial_output_set(unsigned int enabled);
 void serial_flush(void);
 void serial_poll(void);              // poll for serial input
 void serial_replay_output(void);     // re-show all previous serial output


### PR DESCRIPTION
The Picasso IV flicker fixer is exposed through autoconfig, but
its normal register windows are not usable until the board has
been configured.

Configure all visible autoconfig devices during setup, add a lookup
helper for configured boards, and use it to find both Zorro II and
Zorro III Picasso IV flicker fixer variants. Program the PAL or NTSC
timing registers, initialise the POST window, and route native Amiga
video through the flicker fixer when the board is present.

Picasso IV can decode as four different devices:
| physical offset | type | product | manufacturer | flags/extra |
| --- | ---: | ---: | ---: | ---: |
| `0x0000` | `0x31` | `0x15` | `0x0877` | `0x0000` |
| `0x0040` | `0x31` | `0x16` | `0x0877` | `0x0000` |
| `0x0080` | `0x2d` | `0x17` | `0x0877` | `0x0200` |
| `0x00c0` | `0x6e` | `0x18` | `0x0877` | `0x0200` |

For the usual grouped Zorro-II resources, product `0x17` provides the hardware
area used by the flicker-fixer code:

```text
control_base = product_0x17 cd_BoardAddr
regs_base    = product_0x17 cd_BoardAddr + 0x10000
post_base    = product_0x17 cd_BoardAddr + 0x08000
variant      = 0
```

For the product `0x18` resource path:

```text
control_base = product_0x18 cd_BoardAddr
regs_base    = product_0x18 cd_BoardAddr + 0x00600000
post_base    = product_0x18 cd_BoardAddr + 0x00200000
variant      = 1
```

`regs_base` is a VGA-style register window. switcher.rom writes `regs_base+0x3c4`
and `+0x3c5` for sequencer index/data, `+0x3ce` and `+0x3cf` for graphics
controller index/data, and `+0x3d4` and `+0x3d5` for CRTC index/data.

