### PR TITLE
ROM Switcher: make the Copper/VBlank watchdog colors immune to interrupt latency

### DIFF
--- a/romswitcher/screen.c
+++ b/romswitcher/screen.c
@@ -817,6 +817,12 @@ screen_init(void)
      */
     static const uint16_t copperlist[] = {
         0x0001, 0xff00,                   // Wait VPOS=0, HPOS=0
+        /*
+         * Visual watchdog for the VBlank handler, first thing after the
+         * wait so it always lands before the handler can run: if that
+         * handler stops executing, the Black will change to Dark Violet.
+         */
+        0x0182, 0x090d,                   // COLOR01 Dark Violet (overridden by VBlank)
         0x00e0, BITPLANE_0_BASE >> 16,    // BPL1PTH (High address)
         0x00e2, BITPLANE_0_BASE & 0xffff, // BPL1PTL (Low address)
         0x00e4, BITPLANE_1_BASE >> 16,    // BPL2PTH (High address)
@@ -834,13 +840,6 @@ screen_init(void)
     uint sprite;
     uint reg = 0x0120;
     uint32_t data;
-
-    /*
-     * The below is a visual watchdog for the VBlank handler.
-     * If that handler stops executing, the Black will change to Dark Red.
-     */
-    cp[pos++] = 0x0182;  // COLOR01
-    cp[pos++] =  0x90d;  // Set black to Dark Violet (overridden by VBlank)
 
     for (sprite = 0; sprite < 8; sprite++) {
         if (sprite == 0) {

--- a/romswitcher/vectors.c
+++ b/romswitcher/vectors.c
@@ -259,6 +259,7 @@ VBlank(void)
 
     static uint16_t mouse_quad_last = 0xffff;
     uint16_t mouse_quad_cur;
+    static uint8_t cop_miss;
 
     /*
      * The main job of this function is to the reset the bitplane and
@@ -272,10 +273,19 @@ VBlank(void)
     if (*ADKCONR & 0x0400) {
         /* Copper is running */
         *ADKCON = 0x0400;  // Clear "Copper is alive"
+        cop_miss = 0;
         *COLOR01 = 0x000;  // Black when VBlank and Copper are working
-    } else {
-        /* Copper didn't run */
+    } else if (++cop_miss >= 2) {
+        /* Copper didn't run for two frames in a row */
         *COLOR01 = 0x721;  // Copper color when Copper is not working
+    } else {
+        /*
+         * A single miss is normal on a fast CPU: this handler can run
+         * before the Copper has reached its "alive" write in the current
+         * frame, right after having cleared the previous frame's flag.
+         * The handler ran, so override the Copper's Dark Violet.
+         */
+        *COLOR01 = 0x000;
     }
 
     /* Bitplane pointers are normally updated by the Copper */

--- a/romswitcher/vectors.c
+++ b/romswitcher/vectors.c
@@ -275,17 +275,19 @@ VBlank(void)
         *ADKCON = 0x0400;  // Clear "Copper is alive"
         cop_miss = 0;
         *COLOR01 = 0x000;  // Black when VBlank and Copper are working
-    } else if (++cop_miss >= 2) {
-        /* Copper didn't run for two frames in a row */
-        *COLOR01 = 0x721;  // Copper color when Copper is not working
     } else {
         /*
          * A single miss is normal on a fast CPU: this handler can run
          * before the Copper has reached its "alive" write in the current
          * frame, right after having cleared the previous frame's flag.
-         * The handler ran, so override the Copper's Dark Violet.
+         * Two misses in a row mean the Copper really stopped. The counter
+         * saturates so a long outage cannot wrap it back to a single miss.
+         * Either way this handler ran, so override the Copper's Dark
+         * Violet unless the Copper is gone.
          */
-        *COLOR01 = 0x000;
+        if (cop_miss < 2)
+            cop_miss++;
+        *COLOR01 = (cop_miss >= 2) ? 0x721 : 0x000;  // Copper color when Copper is not working
     }
 
     /* Bitplane pointers are normally updated by the Copper */


### PR DESCRIPTION
On an AmigaPCI with a 40 MHz 68040 and working caches, the ROM Switcher's black text flickers dark red. The cause is the "Copper is alive" watchdog: the VBlank handler checks a flag that the Copper only writes about 13 µs into its list, and a cached CPU frequently gets there first. Whether the handler then finds the flag depends on the ordering in the previous frame, so every ordering flip paints one dark red frame. Any 040/060 system with fast interrupt entry can hit this.

Two changes, both in the ROM Switcher only:

- **vectors.c**: paint dark red only after two consecutive misses. A false miss requires the previous handler to have run after the Copper's write and the current one before it, so it can never happen twice in a row; two misses means the Copper really stopped. A single miss still paints black, otherwise the Copper's dark violet CPU watchdog color shows through for that frame (that is what my first attempt produced).
- **screen.c**: the dark violet `COLOR01` write moves to the front of the Copper list, right after the wait, so a fast handler cannot paint black before the Copper has painted violet.

Verified on the AmigaPCI from the MED command line: black stays black; `cw dff096 80` (clear COPEN) turns the text dark red after two frames and `cw dff096 8080` restores it; `cw dff09a 20` (clear VERTB) turns it dark violet and `cw dff09a 8020` restores it.
