### PR TITLE
romswitcher: Fix GUI bevels, spacing and the ROM pointer

### DIFF
--- a/amiga/romswitch.c
+++ b/amiga/romswitch.c
@@ -77,8 +77,10 @@
 
 #define SCREEN_WIDTH         640
 #define SCREEN_HEIGHT        200
-#define BANK_TABLE_YPOS      92
-#define BUTTONS_YPOS         186
+#define BANK_TABLE_XPOS      32
+#define BANK_TABLE_YPOS      88
+#define BANK_ROW_HEIGHT      10  // Eight text pixels plus top/bottom borders
+#define BUTTONS_YPOS         188
 
 #define ID_BOARD_NAME        1
 #define ID_POWERON_RADIO     2
@@ -800,6 +802,17 @@ banktable_widths[] = {
 
 uint banktable_pos[ARRAY_SIZE(banktable_widths)];
 
+static uint
+banktable_width(void)
+{
+    uint width = 0;
+    uint col;
+
+    for (col = 0; col < ARRAY_SIZE(banktable_widths); col++)
+        width += banktable_widths[col] * 8 + 8;
+    return (width);
+}
+
 /*
  * box
  * ---
@@ -854,7 +867,7 @@ show_bank_cell(uint bank, uint col)
     char text[20];
     struct RastPort *rp = &screen->RastPort;
     uint xoff = banktable_pos[col];
-    uint y = BANK_TABLE_YPOS + 2;
+    uint y = bank_box_top + 8;
     uint chars = banktable_widths[col];
 
     memset(text, ' ', chars);
@@ -893,11 +906,11 @@ show_bank_cell(uint bank, uint col)
                 text[4] = '0' + p;
             }
             /* Text between the + and - buttons */
-            Move(rp, xoff + 7 + 4 * 8, y + 21 + bank * 9);
+            Move(rp, xoff + 7 + 4 * 8, y + bank * BANK_ROW_HEIGHT);
             Text(rp, text + 4, 1);
 
             /* Text to the right of the + button */
-            Move(rp, xoff + 3 + 8 * 8, y + 21 + bank * 9);
+            Move(rp, xoff + 3 + 8 * 8, y + bank * BANK_ROW_HEIGHT);
             Text(rp, text, 2);
 
             /* Text to the left of the - button */
@@ -908,7 +921,7 @@ show_bank_cell(uint bank, uint col)
             chars = 2;
 skip_center_button:
             /* Text to the right of the button */
-            Move(rp, xoff + 35 + chars * 8, y + 21 + bank * 9);
+            Move(rp, xoff + 35 + chars * 8, y + bank * BANK_ROW_HEIGHT);
             Text(rp, text, chars);
             break;
         case 5: // Current
@@ -921,7 +934,7 @@ skip_center_button:
             chars = 3;
             goto skip_center_button;
     }
-    Move(rp, xoff + 3, y + 21 + bank * 9);
+    Move(rp, xoff + 3, y + bank * BANK_ROW_HEIGHT);
     Text(rp, text, chars);
 }
 
@@ -994,38 +1007,37 @@ static void
 show_banks(void)
 {
     uint col;
-    uint x = 32;
+    uint x = BANK_TABLE_XPOS;
     uint y = BANK_TABLE_YPOS;
     uint xoff;
-    uint width;
+    uint width = banktable_width();
     struct RastPort *rp = &screen->RastPort;
-
-    for (width = 0, col = 0; col < ARRAY_SIZE(banktable_widths); col++)
-        width += banktable_widths[col] * 8 + 8;
 
     SetAPen(&screen->RastPort, 1);  // Black
     Print("Bank       Name         Merge  LongReset  PowerOn  Current  ",
-          x + 10, y + 10, FALSE);
+          x + 10, y + 11, FALSE);
     Print("SwitchTo",
-          x + width - banktable_widths[col - 1] * 8 + 6, y + 10, FALSE);
+          x + width - banktable_widths[ARRAY_SIZE(banktable_widths) - 1] * 8 + 6,
+          y + 11, FALSE);
 
     SetAPen(rp, 1);
-    box(x, y, width + 6, 18 + ROM_BANKS * 9, GTBB_Recessed);
+    box(x, y, width + 6, 17 + ROM_BANKS * BANK_ROW_HEIGHT, GTBB_Recessed);
     y += 2;
     xoff = x + 3;
-    bank_box_top = y + 14;
-    bank_box_bottom = y + 12 + 4 + ROM_BANKS * 9;
+    bank_box_top = y + 12;
+    bank_box_bottom = bank_box_top + ROM_BANKS * BANK_ROW_HEIGHT;
     bank_box_left = xoff;
     bank_box_right = xoff + width;
     for (col = 0; col < ARRAY_SIZE(banktable_widths); col++) {
         uint pwidth = banktable_widths[col] * 8 + 8;
         banktable_pos[col] = xoff;
 
-        /* Title box */
-        box(xoff, y, pwidth, 12, TAG_IGNORE);
+        /* End above the column's white top edge. */
+        box(xoff, y, pwidth, 11, TAG_IGNORE);
 
-        /* Column box */
-        box(xoff, y + 12, pwidth, 3 + ROM_BANKS * 9, TAG_IGNORE);
+        /* Keep the column borders clear of the first and last rows. */
+        box(xoff, bank_box_top - 1, pwidth,
+            ROM_BANKS * BANK_ROW_HEIGHT + 2, TAG_IGNORE);
 
         show_bank_table_column(col);
 
@@ -1042,7 +1054,7 @@ show_banks(void)
 static void
 bank_mouseover(uint pos)
 {
-    uint bank = pos / 9;
+    uint bank = pos / BANK_ROW_HEIGHT;
     uint col;
     struct RastPort *rp;
 
@@ -1446,7 +1458,7 @@ cleanup_bank_name_gadgets(void)
         sbox(x1 + 2, y, 0, 7);
         sbox(x2, y, 1, 7);
         sbox(x2 + 2, y, 0, 7);
-        y += 9;
+        y += BANK_ROW_HEIGHT;
     }
 }
 #endif
@@ -1496,7 +1508,7 @@ draw_page(void)
     char buf[32];
     sprintf(buf, "KickSmash ROM switcher %3s", VERSION);
     Print(buf, 0, 10, TRUE);
-    box(40, 0, 560, 14, GTBB_Recessed);
+    box(BANK_TABLE_XPOS, 0, banktable_width() + 6, 14, GTBB_Recessed);
 
     gadgets = CreateContext(&LastAdded);
 
@@ -1513,7 +1525,7 @@ draw_page(void)
     ng.ng_Width = 14;
     ng.ng_Height     = 8;
     for (bank = 0; bank < ROM_BANKS; bank++) {
-        ng.ng_TopEdge = bank_box_top + 9 * bank;
+        ng.ng_TopEdge = bank_box_top + 1 + BANK_ROW_HEIGHT * bank;
         ng.ng_LeftEdge = banktable_pos[3] + 6 + 2 * 8;
         ng.ng_GadgetID = ID_LONGRESET_MINUS_0 + bank;
         ng.ng_GadgetText = "-";
@@ -1529,7 +1541,8 @@ draw_page(void)
     char *current_sel_labels[] = { "", NULL };
     ng.ng_Width      = 26;
     ng.ng_Height     = 8;
-    ng.ng_TopEdge  = bank_box_top + 9 * info.bi_bank_current;
+    ng.ng_TopEdge  = bank_box_top + 1 +
+                     BANK_ROW_HEIGHT * info.bi_bank_current;
     ng.ng_LeftEdge = (banktable_pos[6] + banktable_pos[5] -
                       ng.ng_Width) / 2 - 1;
     ng.ng_GadgetID = ID_CURRENT_RADIO;
@@ -1537,19 +1550,19 @@ draw_page(void)
     LastAdded = CreateGadget(MX_KIND, LastAdded, NewGadget,
                              GTMX_Labels, (ULONG) current_sel_labels,
                              GTMX_Active, (UWORD) 0,
-                             GTMX_Spacing, (UWORD) 1,
+                             GTMX_Spacing, (UWORD) (BANK_ROW_HEIGHT - 8),
                              GTMX_Scaled, TRUE,
                              TAG_DONE);
 
     /* ROM bank names */
-    ng.ng_Height     = 9;
+    ng.ng_Height     = BANK_ROW_HEIGHT;
     ng.ng_GadgetText = NULL;
     ng.ng_LeftEdge   = banktable_pos[1];
     ng.ng_Width      = banktable_pos[2] - banktable_pos[1];
     for (bank = 0; bank < ROM_BANKS; bank++) {
         sptr = info.bi_name[bank];
         ng.ng_GadgetID   = ID_BANK_NAME_0 + bank;
-        ng.ng_TopEdge    = bank_box_top + bank * 9;
+        ng.ng_TopEdge    = bank_box_top + bank * BANK_ROW_HEIGHT;
 
         LastAdded = CreateGadget(STRING_KIND, LastAdded, NewGadget,
                                  GTST_MaxChars, sizeof (info.bi_name[0]) - 1,
@@ -1598,6 +1611,9 @@ draw_page(void)
                              GA_DISABLED, disabled_save,
                              GT_Underscore, '_',
                              TAG_DONE);
+#ifdef STANDALONE
+    LastAdded->GadgetText->TopEdge = 0;
+#endif
     gadget_save = LastAdded;
     gadget_save_x = ng.ng_LeftEdge - 3;
     gadget_save_y = ng.ng_TopEdge - 2;
@@ -1610,6 +1626,9 @@ draw_page(void)
     ng.ng_GadgetText = "_Cancel";
     ng.ng_GadgetID   = ID_CANCEL;
     LastAdded = create_gadget(BUTTON_KIND);
+#ifdef STANDALONE
+    LastAdded->GadgetText->TopEdge = 0;
+#endif
     gadget_cancel_x = ng.ng_LeftEdge - 3;
     gadget_cancel_y = ng.ng_TopEdge - 2;
     gadget_cancel_w = ng.ng_Width + 5;
@@ -1626,6 +1645,9 @@ draw_page(void)
                              GA_DISABLED, disabled_switch,
                              GT_Underscore, '_',
                              TAG_DONE);
+#ifdef STANDALONE
+    LastAdded->GadgetText->TopEdge = 0;
+#endif
     gadget_switch_x = ng.ng_LeftEdge - 3;
     gadget_switch_y = ng.ng_TopEdge - 2;
     gadget_switch_w = ng.ng_Width + 5;
@@ -1703,7 +1725,7 @@ draw_page(void)
 
     /* PowerOn select radio */
     char *poweron_sel_labels[] = { "", "", "", "", "", "", "", "", NULL };
-    ng.ng_TopEdge    = bank_box_top;
+    ng.ng_TopEdge    = bank_box_top + 1;
     ng.ng_Width      = 26;
     ng.ng_LeftEdge   = (banktable_pos[5] + banktable_pos[4] -
                         ng.ng_Width) / 2 - 1;
@@ -1713,7 +1735,7 @@ draw_page(void)
     LastAdded = CreateGadget(MX_KIND, LastAdded, NewGadget,
                              GTMX_Labels, (ULONG) poweron_sel_labels,
                              GTMX_Active, (UWORD) info.bi_bank_poweron,
-                             GTMX_Spacing, (UWORD) 1,
+                             GTMX_Spacing, (UWORD) (BANK_ROW_HEIGHT - 8),
                              GTMX_Scaled, TRUE,
                              GA_Immediate, TRUE,
 //                           GA_DISABLED, TRUE,
@@ -1722,14 +1744,14 @@ draw_page(void)
     /* SwitchTo select radio */
     gadget_switchto_pre = LastAdded;
     ng.ng_Width      = 26;
-    ng.ng_TopEdge = bank_box_top;
+    ng.ng_TopEdge = bank_box_top + 1;
     ng.ng_LeftEdge = banktable_pos[6] +
                      (banktable_widths[6] * 8 - ng.ng_Width) / 2 + 3;
     ng.ng_GadgetID = ID_SWITCHTO_RADIO;
     LastAdded = CreateGadget(MX_KIND, LastAdded, NewGadget,
                              GTMX_Labels, (ULONG) poweron_sel_labels,
                              GTMX_Active, (UWORD) bank_switchto,
-                             GTMX_Spacing, (UWORD) 1,
+                             GTMX_Spacing, (UWORD) (BANK_ROW_HEIGHT - 8),
                              GTMX_Scaled, TRUE,
                              TAG_DONE);
     gadget_switchto = LastAdded;

--- a/amiga/romswitch.c
+++ b/amiga/romswitch.c
@@ -838,6 +838,12 @@ sbox(uint x, uint y, uint w, uint h)
 {
     struct RastPort *rp = &screen->RastPort;
     WORD da[8];
+
+    /* Bottom-button keyboard outlines must fit the 200-line screen. */
+    if (y >= SCREEN_HEIGHT)
+        return;
+    h = MIN(h, SCREEN_HEIGHT - 1 - y);
+
     da[0] = x + w;
     da[1] = y;
     da[2] = x + w;

--- a/amiga/romswitch.c
+++ b/amiga/romswitch.c
@@ -1330,7 +1330,7 @@ show_bank_timeout(void)
     ng.ng_VisualInfo = visualInfo;
 
     ng.ng_Width      = 30;
-    ng.ng_Height     = 10;
+    ng.ng_Height     = 11;
     ng.ng_TopEdge    = 43;
     ng.ng_LeftEdge   = 541;
     ng.ng_GadgetText = "Bank";
@@ -1343,8 +1343,8 @@ show_bank_timeout(void)
     gadget_timeout_bank = LastAdded;
 
     ng.ng_Width      = 52;
-    ng.ng_Height     = 10;
-    ng.ng_TopEdge    = 56;
+    ng.ng_Height     = 11;
+    ng.ng_TopEdge    = 57;
     ng.ng_LeftEdge   = 541;
     ng.ng_GadgetText = "Timeout";
     ng.ng_GadgetID   = ID_BANK_TIMEOUT;

--- a/romswitcher/Makefile
+++ b/romswitcher/Makefile
@@ -126,7 +126,7 @@ $(OBJDIR)/main.o: ../fw/version.c $(filter-out $(OBJDIR)/main.o,$(OBJS))
 
 $(OBJS): amiga_chipset.h screen.h printf.h util.h serial.h timer.h
 $(OBJDIR)/serial.o: keyboard.h
-$(OBJDIR)/sprite.o: sprite.h
+$(OBJDIR)/sprite.o $(OBJDIR)/vectors.o: sprite.h
 $(OBJDIR)/main.o: sprite.h keyboard.h reset.h picassoiv.h
 $(OBJDIR)/picassoiv.o: autoconfig.h picassoiv.h timer.h cache.h
 $(OBJDIR)/draw.o: draw.h intuition.h

--- a/romswitcher/gadget.c
+++ b/romswitcher/gadget.c
@@ -754,8 +754,8 @@ uint
 gadget_string_calc_y(Gadget *gad)
 {
     uint y = gad->TopEdge + 1;
-    if (gad->Height > FONT_HEIGHT + 3)
-        y = gad->TopEdge + (gad->Height - FONT_HEIGHT) / 2;
+    if (gad->Height > FONT_HEIGHT + 1)
+        y = gad->TopEdge + (gad->Height - FONT_HEIGHT + 1) / 2;
     return (y);
 }
 
@@ -785,7 +785,7 @@ static void
 gadget_draw_string(Gadget *gad)
 {
     uint x = gad->LeftEdge;
-    uint y = gad->TopEdge;
+    uint y = gadget_string_calc_y(gad);
     struct IntuiText *it = gad->GadgetText;
 
     /*
@@ -805,7 +805,7 @@ gadget_draw_string(Gadget *gad)
         }
         // XXX: Maybe this clipping intelligence should be built into
         //      render_text_at() so it can always trim to the screen borders.
-        render_text_at(it->IText + rstart, 0, rpos, y + it->TopEdge,
+        render_text_at(it->IText + rstart, 0, rpos, y + it->TopEdge - 1,
                        it->FrontPen, it->BackPen);
     }
     gadget_update_string(gad, GADGET_STRING_UPDATE_ALL);

--- a/romswitcher/gadget.c
+++ b/romswitcher/gadget.c
@@ -404,6 +404,7 @@ DrawBevelBox(RastPort *rp, long left, long top, long width, long height,
         }
         tag1 = va_arg(ap, ULONG);
     }
+    va_end(ap);
 
     switch (boxtype) {
         default:
@@ -426,24 +427,19 @@ DrawBevelBox(RastPort *rp, long left, long top, long width, long height,
             /* box for STRING_KIND and INTEGER_KIND gadgets */
             int x1 = left;
             int x2 = left + width - 1;
-            int y1 = top + 1;
-            int y2 = top + height;
-            if (y1 - y2 > FONT_HEIGHT + 1) {
-                draw_line(bot_pen, x1, y2 + 1, x2, y2 + 1);
-                draw_line(bot_pen, x2, y1 - 1, x2, y2 + 1);
-                draw_line(top_pen, x1, y2, x2 - 1, y2);
-                draw_line(top_pen, x2 - 1, y1 - 1, x2 - 1, y2);
-            } else {
-                draw_line(bot_pen, x1, y2, x2 - 1, y2);
-                draw_line(bot_pen, x2 - 1, y1 - 1, x2 - 1, y2);
-            }
-// printf("[%u]", y2 - y1);
-            if (y1 - y2 > FONT_HEIGHT + 1) {
-                draw_line(bot_pen, x1 + 1, y1, x2 - 1, y1 + 1);
-                draw_line(bot_pen, x1 + 1, y1, x1 + 1, y2 + 1);
-            }
-            draw_line(top_pen, x1, y1 - 1, x2, y1 - 1);
-            draw_line(top_pen, x1, y1 - 1, x1, y2 + 1);
+            int y1 = top;
+            int y2 = top + height - 1;
+
+            if ((width < 4) || (height < 2))
+                break;
+
+            /* Split the two-pixel corner joins between light and dark. */
+            draw_line(top_pen, x1, y1, x2 - 1, y1);
+            draw_line(top_pen, x1, y1, x1, y2);
+            draw_line(top_pen, x1 + 1, y1, x1 + 1, y2 - 1);
+            draw_line(bot_pen, x1 + 1, y2, x2, y2);
+            draw_line(bot_pen, x2 - 1, y1 + 1, x2 - 1, y2);
+            draw_line(bot_pen, x2, y1, x2, y2);
             break;
         }
     }
@@ -464,9 +460,7 @@ gadget_draw_bounding_box(Gadget *gad, uint boxtype, uint is_recessed)
 // "KickSmash ROM switcher" top box has black on top/left and white on bot/right
 //      GTBB_Recessed
 // Save/Cancel/Reboot buttons have white on top/left and black on bot/right
-// Board name box has two layers of different colors at each border.
-//      White is always left/top
-//      Black is always right/bottom
+// String fields have black top/left and white bottom/right borders.
 // Table exterior box has two layers, maybe done manually
 //      Outside has black left/top
 
@@ -818,7 +812,7 @@ gadget_draw_string(Gadget *gad)
 
     /* Default is to draw border, turn off using GTTX_BORDER tag */
     if (gad->Flags & GFLG_GADGHBOX)
-        gadget_draw_bounding_box(gad, BBFT_RIDGE, FALSE);
+        gadget_draw_bounding_box(gad, BBFT_RIDGE, TRUE);
 }
 
 static void

--- a/romswitcher/sprite.c
+++ b/romswitcher/sprite.c
@@ -66,29 +66,21 @@ sprite_init(void)
      */
 
     /*
-     *      Mouse         White         Black
-     * W W . . . . . .    11000000 c0   00000000 00
-     * W B W . . . . .    10100000 a0   01000000 40
-     * W B B W . . . .    10010000 90   01100000 60
-     * W B B B W . . .    10001000 88   01110000 70
-     * W B B W W W . .    10011100 9c   01100000 60
-     * W W B B W . . .    11001000 c8   00110000 30
-     * W . W B B W . .    10100100 a4   00011000 18
-     * . . W B B W . .    00100100 24   00011000 18
-     * . . . W W . . .    00011000 18   00000000 00
+     * Mouse pointer bitmap, interleaved for sprite DMA.
+     * The last five rows are transparent.
      */
+    static const uint32_t mouse_image[MOUSE_SPRITE_HEIGHT] = {
+        0xc0004000, 0x7000b000, 0x3c004c00, 0x3f004300,
+        0x1fc020c0, 0x1fc02000, 0x0f001100, 0x0d801280,
+        0x04c00940, 0x046008a0, 0x00200040, 0x00000000,
+        0x00000000, 0x00000000, 0x00000000, 0x00000000,
+    };
+
     sprite0_data = (uint32_t *) 0x1080;  // chip RAM address
-    sprite0_data[0] = 0x2c494000;  // HSTART, VSTART, VSTOP, control bits
-    sprite0_data[1] = 0xc0000000;
-    sprite0_data[2] = 0xa0004000;
-    sprite0_data[3] = 0x90006000;
-    sprite0_data[4] = 0x88007000;
-    sprite0_data[5] = 0x9c006000;
-    sprite0_data[6] = 0xc8003000;
-    sprite0_data[7] = 0xa4001800;
-    sprite0_data[8] = 0x24001800;
-    sprite0_data[9] = 0x18000000;
-    sprite0_data[10] = 0x00000000;
+    sprite0_data[0] = sprite_calcpos(0x80 + MOUSE_SPRITE_XOFFSET,
+                                    0x2c, 0x2c + MOUSE_SPRITE_HEIGHT);
+    memcpy(sprite0_data + 1, mouse_image, sizeof (mouse_image));
+    sprite0_data[MOUSE_SPRITE_HEIGHT + 1] = 0x00000000;
 
     /*
      *     Cursor
@@ -102,7 +94,7 @@ sprite_init(void)
      * O O O O O O O O
      * O O O O O O O O
      */
-    sprite1_data = sprite0_data + 11;
+    sprite1_data = sprite0_data + MOUSE_SPRITE_HEIGHT + 2;
     sprite1_data[0] = 0x2c403400;  // HSTART, VSTART, VSTOP, control bits
     sprite1_data[1] = 0xf000f000;
     sprite1_data[2] = 0xf000f000;
@@ -114,28 +106,14 @@ sprite_init(void)
     sprite1_data[8] = 0xf000f000;  // next sprite usage (0x0000000 = last usage)
     sprite1_data[9] = 0x00000000;
 
+    /* A disabled sprite only needs its zero position/control pair. */
     spritex_data = sprite1_data + 10;
-    spritex_data[0] = 0x00000000;  // HSTART, VSTART, VSTOP, control bits
-    spritex_data[1] = 0x00000000;
-    spritex_data[2] = 0x00000000;
-    spritex_data[3] = 0x00000000;
-    spritex_data[4] = 0x00000000;
-    spritex_data[5] = 0x00000000;
-    spritex_data[6] = 0x00000000;
-    spritex_data[7] = 0x00000000;
-    spritex_data[8] = 0x00000000;
-    spritex_data[9] = 0x00000000;  // next sprite usage (0x0000000 = last usage)
+    spritex_data[0] = 0x00000000;
 
-//  *SPR0POS = 0x2c20;
-//  *SPR0CTL = 0x0800;
-//  *SPR0DATA = 0x0800;
-//  *SPR0DATB = 0x0800;
-
-    // 0xdc0 is yellow, 0x840 is orange-brown
-    // Sprite color 0 is always transparent mode
-    *COLOR17 = 0xfff;  // Sprite 0 and 1 color 1   white
+    /* Mouse pointer colors. */
+    *COLOR17 = 0xe44;  // Sprite 0 and 1 color 1   red
     *COLOR18 = 0x000;  // Sprite 0 and 1 color 2   black
-    *COLOR19 = 0x44f;  // Sprite 0 and 1 color 3
+    *COLOR19 = 0xeec;  // Sprite 0 and 1 color 3   cream
 
     *COLOR21 = 0x04f;  // Sprite 2 and 3 color 1
     *COLOR22 = 0x4f0;  // Sprite 2 and 3 color 2

--- a/romswitcher/sprite.h
+++ b/romswitcher/sprite.h
@@ -16,6 +16,9 @@
 #ifndef _SPRITE_H
 #define _SPRITE_H
 
+#define MOUSE_SPRITE_HEIGHT 16
+#define MOUSE_SPRITE_XOFFSET (-1)
+
 void sprite_init(void);
 uint sprite_calcpos(uint x_start, uint y_start, uint y_end);
 

--- a/romswitcher/vectors.c
+++ b/romswitcher/vectors.c
@@ -337,9 +337,9 @@ VBlank(void)
      */
 
     /* Position mouse pointer */
-    uint x_start = mouse_x / 2 + 0x80;  // Sprite X position is lowres
+    uint x_start = mouse_x / 2 + 0x80 + MOUSE_SPRITE_XOFFSET;
     uint y_start = mouse_y + 0x2c;
-    uint y_end   = y_start + 9;
+    uint y_end   = y_start + MOUSE_SPRITE_HEIGHT;
 
     /* Mouse pointer */
     if (sprite0_data != NULL) {


### PR DESCRIPTION
The ROM switcher had string-field corner overruns, overlapping bank-name borders, and a small black mouse pointer. This fixes the bevel geometry, gives each bank row enough room for separate black top and white bottom edges, and use a pointer more similar to the AmigaOS 3.1 red pointer.

The title and bank-table frames now share their horizontal bounds. Header text, nested borders, and bottom-button labels are aligned, with the buttons fitting on scanlines 188–199. Keyboard-activation outlines are constrained to the 200-line display. Radio and +/- controls retain their eight-pixel height; ten-pixel rows leave two pixels between controls.

The changes are split into four commits: field bevels, table/title/button layout, pointer restoration, and keyboard-outline bounds. The larger pointer and cursor data remain within the reserved 128-byte sprite area.

Validation:
- Built the standalone ROM from a fresh object directory with GCC 13.4.
- Ad hoc host checks passed for field bounds, corner pixels, adjacent-row redraws, column-frame coordinates, and keyboard-outline bounds. The field-bounds check reproduces the overrun in the original code.

Closes https://github.com/cdhooper/kicksmash32/issues/43
